### PR TITLE
upgrade deno to v1.2.0 in workflows and update std/test to v0.61.0

### DIFF
--- a/.github/workflows/ts_serialize_release.yml
+++ b/.github/workflows/ts_serialize_release.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
       - name: run tests
         run: |
-          curl -L https://deno.land/x/install/install.sh | sh -s "v1.0.5"
+          curl -L https://deno.land/x/install/install.sh | sh -s "v1.2.0"
           export PATH="$HOME/.deno/bin:$PATH"
           deno fmt --check
           deno test -c tsconfig.json

--- a/.github/workflows/ts_serialize_tests.yml
+++ b/.github/workflows/ts_serialize_tests.yml
@@ -13,7 +13,7 @@ jobs:
       - name: run tests
         run: |
           .github/workflows/scripts/create_npm_package_file_test.sh
-          curl -L https://deno.land/x/install/install.sh | sh -s "v1.0.5"
+          curl -L https://deno.land/x/install/install.sh | sh -s "v1.2.0"
           export PATH="$HOME/.deno/bin:$PATH"
           deno fmt --check
           deno test -c tsconfig.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- upgrade deno@1.2.0 and std/test@0.61.0
+
+## [v0.1.0] - 2020-6-25
+
+### Changed
+
 - various ci related things
 - added `fromJsonAs` exported function
 

--- a/serialize_property_options_map_test.ts
+++ b/serialize_property_options_map_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 Gamebridge.ai authors. All rights reserved. MIT license.
 
-import { test, assertEquals, assertStrictEq, fail } from "./test_deps.ts";
+import { test, assertEquals, assertStrictEquals, fail } from "./test_deps.ts";
 import {
   SerializePropertyOptionsMap,
   ERROR_MESSAGE_DUPLICATE_PROPERTY_KEY,
@@ -25,8 +25,8 @@ test({
 
     assertEquals(test.hasPropertyKey("a"), true);
     assertEquals(test.hasSerializedKey("b"), true);
-    assertStrictEq(test.getByPropertyKey("a"), spOptions);
-    assertStrictEq(test.getBySerializedKey("b"), spOptions);
+    assertStrictEquals(test.getByPropertyKey("a"), spOptions);
+    assertStrictEquals(test.getBySerializedKey("b"), spOptions);
 
     const allPropertyOptions = Array.from(test.propertyOptions());
     assertEquals(allPropertyOptions.length, 1);
@@ -45,8 +45,8 @@ test({
 
     assertEquals(test.hasPropertyKey("a"), true);
     assertEquals(test.hasSerializedKey("b"), true);
-    assertStrictEq(test.getByPropertyKey("a"), spOptions);
-    assertStrictEq(test.getBySerializedKey("b"), spOptions);
+    assertStrictEquals(test.getByPropertyKey("a"), spOptions);
+    assertStrictEquals(test.getBySerializedKey("b"), spOptions);
 
     const allPropertyOptions = Array.from(test.propertyOptions());
     assertEquals(allPropertyOptions.length, 1);
@@ -67,8 +67,8 @@ test({
 
     assertEquals(test.hasPropertyKey("a"), true);
     assertEquals(test.hasSerializedKey("b"), true);
-    assertStrictEq(test.getByPropertyKey("a"), childSPOptions);
-    assertStrictEq(test.getBySerializedKey("b"), childSPOptions);
+    assertStrictEquals(test.getByPropertyKey("a"), childSPOptions);
+    assertStrictEquals(test.getBySerializedKey("b"), childSPOptions);
 
     const allPropertyOptions = Array.from(test.propertyOptions());
     assertEquals(allPropertyOptions.length, 1);
@@ -139,11 +139,11 @@ test({
     const childSPOptions = new SerializePropertyOptions("b", "a");
     testChild.set(childSPOptions);
 
-    assertStrictEq(testChild.getByPropertyKey("b"), childSPOptions);
-    assertStrictEq(testChild.getByPropertyKey("a"), undefined);
+    assertStrictEquals(testChild.getByPropertyKey("b"), childSPOptions);
+    assertStrictEquals(testChild.getByPropertyKey("a"), undefined);
 
-    assertStrictEq(testChild.hasPropertyKey("b"), true);
-    assertStrictEq(testChild.hasPropertyKey("a"), false);
+    assertStrictEquals(testChild.hasPropertyKey("b"), true);
+    assertStrictEquals(testChild.hasPropertyKey("a"), false);
 
     const childEntries = Array.from(testChild.propertyOptions());
     assertEquals(childEntries.length, 1);
@@ -163,11 +163,11 @@ test({
     const childSPOptions = new SerializePropertyOptions("a", "b");
     testChild.set(childSPOptions);
 
-    assertStrictEq(testChild.getBySerializedKey("b"), childSPOptions);
-    assertStrictEq(testChild.getBySerializedKey("a"), undefined);
+    assertStrictEquals(testChild.getBySerializedKey("b"), childSPOptions);
+    assertStrictEquals(testChild.getBySerializedKey("a"), undefined);
 
-    assertStrictEq(testChild.hasSerializedKey("b"), true);
-    assertStrictEq(testChild.hasSerializedKey("a"), false);
+    assertStrictEquals(testChild.hasSerializedKey("b"), true);
+    assertStrictEquals(testChild.hasSerializedKey("a"), false);
 
     const childEntries = Array.from(testChild.propertyOptions());
     assertEquals(childEntries.length, 1);
@@ -189,11 +189,11 @@ test({
     const childSPOptions2 = new SerializePropertyOptions("a", "c");
     testChild.set(childSPOptions2);
 
-    assertStrictEq(testChild.getByPropertyKey("b"), childSPOptions);
-    assertStrictEq(testChild.getByPropertyKey("a"), childSPOptions2);
+    assertStrictEquals(testChild.getByPropertyKey("b"), childSPOptions);
+    assertStrictEquals(testChild.getByPropertyKey("a"), childSPOptions2);
 
-    assertStrictEq(testChild.hasPropertyKey("b"), true);
-    assertStrictEq(testChild.hasPropertyKey("a"), true);
+    assertStrictEquals(testChild.hasPropertyKey("b"), true);
+    assertStrictEquals(testChild.hasPropertyKey("a"), true);
 
     const childEntries = Array.from(testChild.propertyOptions());
     assertEquals(childEntries.length, 2);
@@ -216,11 +216,11 @@ test({
     const childSPOptions2 = new SerializePropertyOptions("c", "a");
     testChild.set(childSPOptions2);
 
-    assertStrictEq(testChild.getBySerializedKey("b"), childSPOptions);
-    assertStrictEq(testChild.getBySerializedKey("a"), childSPOptions2);
+    assertStrictEquals(testChild.getBySerializedKey("b"), childSPOptions);
+    assertStrictEquals(testChild.getBySerializedKey("a"), childSPOptions2);
 
-    assertStrictEq(testChild.hasSerializedKey("b"), true);
-    assertStrictEq(testChild.hasSerializedKey("a"), true);
+    assertStrictEquals(testChild.hasSerializedKey("b"), true);
+    assertStrictEquals(testChild.hasSerializedKey("a"), true);
 
     const childEntries = Array.from(testChild.propertyOptions());
     assertEquals(childEntries.length, 2);

--- a/serialize_property_test.ts
+++ b/serialize_property_test.ts
@@ -4,7 +4,7 @@ import {
   test,
   assert,
   assertEquals,
-  assertStrictEq,
+  assertStrictEquals,
   fail,
 } from "./test_deps.ts";
 import { Serializable } from "./serializable.ts";
@@ -174,7 +174,7 @@ test({
       null!: null;
     }
     const test = new Test().fromJson(`{"null":null}`);
-    assertStrictEq(test.null, null);
+    assertStrictEquals(test.null, null);
   },
 });
 

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -5,6 +5,6 @@ export const { test } = Deno;
 export {
   assert,
   assertEquals,
-  assertStrictEq,
+  assertStrictEquals,
   fail,
-} from "https://deno.land/std@0.55.0/testing/asserts.ts";
+} from "https://deno.land/std@0.61.0/testing/asserts.ts";


### PR DESCRIPTION
## Description

upgrade deno to v1.2.0 in workflows and update std/test to v0.61.0

## Proposed changes in this PR

assertStrictEq -> assertStrictEquals

## Things to look at

- [x] Test coverage
- [x] Code Style
- [x] Documentation (READMEs etc)
