### PR TITLE
Update release script to transpile esmodule code into commonjs for node

### DIFF
--- a/.github/workflows/ts_serialize_release.yml
+++ b/.github/workflows/ts_serialize_release.yml
@@ -29,13 +29,18 @@ jobs:
         run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
       - name: Build project
         run: |
           .github/workflows/scripts/create_npm_package_file_test.sh
           curl -L https://deno.land/x/install/install.sh | sh -s "v1.0.5"
           export PATH="$HOME/.deno/bin:$PATH"
           mkdir dist
-          deno bundle -c tsconfig.json mod.ts dist/index.js
+          npm install @babel/core @babel/cli @babel/preset-env @babel/plugin-transform-modules-commonjs @babel/plugin-transform-runtime
+          deno bundle -c tsconfig.json mod.ts | node_modules/.bin/babel --presets=@babel/preset-env --plugins=@babel/plugin-transform-modules-commonjs,@babel/plugin-transform-runtime --no-babelrc -- > dist/index.js
           cp CHANGELOG.md dist
           cp README.md dist
           cp LICENSE dist

--- a/.github/workflows/ts_serialize_release.yml
+++ b/.github/workflows/ts_serialize_release.yml
@@ -39,8 +39,8 @@ jobs:
           curl -L https://deno.land/x/install/install.sh | sh -s "v1.0.5"
           export PATH="$HOME/.deno/bin:$PATH"
           mkdir dist
-          npm install @babel/core @babel/cli @babel/preset-env @babel/plugin-transform-modules-commonjs @babel/plugin-transform-runtime
-          deno bundle -c tsconfig.json mod.ts | node_modules/.bin/babel --presets=@babel/preset-env --plugins=@babel/plugin-transform-modules-commonjs,@babel/plugin-transform-runtime --no-babelrc -- > dist/index.js
+          npm install @babel/core @babel/cli @babel/preset-env @babel/plugin-transform-modules-commonjs
+          deno bundle -c tsconfig.json mod.ts | node_modules/.bin/babel --presets=@babel/preset-env --plugins=@babel/plugin-transform-modules-commonjs --no-babelrc -- > dist/index.js
           cp CHANGELOG.md dist
           cp README.md dist
           cp LICENSE dist


### PR DESCRIPTION
## Fixes

_Please link to the issue this PR addresses_

## Description

WIP - This is disgusting but it works

How to generate a usable index.js:
- run `npm install @babel/core @babel/cli @babel/preset-env @babel/plugin-transform-modules-commonjs` in the project root
- Run `deno bundle -c tsconfig.json mod.ts | node_modules/.bin/babel --presets=@babel/preset-env --plugins=@babel/plugin-transform-modules-commonjs --no-babelrc -- > index.js`
This will bundle the deno ts code into a js ESModule, then use babel to convert the ESNext features using polyfills, and convert the ESModule into a commonjs module, which node can consume
- Create a new directory, then `cd` into it
- Copy `index.js` into this new directory
- Create the following typescript file:
`serialize-test.ts`
```ts
import { strict as assert } from 'assert';
// @ts-ignore
import { Serializable, SerializeProperty } from "./index";

class Test extends Serializable {
    @SerializeProperty()
    testName = "toJson";
  }
  // @ts-ignore
  assert.strictEqual(new Test().toJson(), `{"testName":"toJson"}`);
  // @ts-ignore
  console.log(new Test().toJson())
  // @ts-ignore
  const test = new Test().fromJson(`{"testName":"fromJson"}`);
  assert.strictEqual(test.testName, "fromJson");
  console.log(test)
```
- And the following ts config file:
`tsconfig.json`
```JSON
{
  "compilerOptions": {
    "target": "es5",
    "module": "commonjs",
    "experimentalDecorators": true,
    "forceConsistentCasingInFileNames": true
  }
}
```
- install typescript `npm install -g typescript`
- run `tsc` to compile `serialize-test.ts` into `serialize-test.js`
- run `node serialize-test.js`, you should see the following output:
```js
{"testName":"toJson"}
Test { testName: 'fromJson' }
```
## Proposed changes in this PR

- foo
- bar
- baz

## Things to look at

- [ ] Test coverage
- [ ] Code Style
- [ ] Documentation (READMEs etc)
