### PR TITLE
Nodejs integration test improvements

### DIFF
--- a/.github/workflows/scripts/build.sh
+++ b/.github/workflows/scripts/build.sh
@@ -29,14 +29,16 @@ cd dist
 
 ../.github/workflows/scripts/npm_release_files/create_npm_package_file.sh "$1"
 
-npm install
+# TODO: No dependancies, so no need to install?
+# npm install
 
 npm link
 
 cd ../examples/node
 
-npm i @gamebridgeai/ts_serialize typescript @types/node
-
+# Slight concern here: We aren't using a lockfile for these test dependencies,
+# so it's possible we may get an error here if the types or ts release a breaking change of some kind
+npm i typescript @types/node
 npm link @gamebridgeai/ts_serialize
 
 npm test

--- a/.github/workflows/scripts/build.sh
+++ b/.github/workflows/scripts/build.sh
@@ -29,16 +29,10 @@ cd dist
 
 ../.github/workflows/scripts/npm_release_files/create_npm_package_file.sh "$1"
 
-# TODO: No dependancies, so no need to install?
-# npm install
-
-npm link
-
+# Test currently built deployment on node example
 cd ../examples/node
 
-# Slight concern here: We aren't using a lockfile for these test dependencies,
-# so it's possible we may get an error here if the types or ts release a breaking change of some kind
-npm i typescript @types/node
-npm link @gamebridgeai/ts_serialize
+npm ci
+npm ln ../../dist
 
 npm test

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ examples/node/*
 !examples/node/node.ts
 !examples/node/tsconfig.json
 !examples/node/package.json
+!examples/node/package-lock.json
 !examples/node/README.md
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,5 @@ examples/node/*
 !examples/node/node.ts
 !examples/node/tsconfig.json
 !examples/node/package.json
-!examples/node/package-lock.json
 !examples/node/README.md
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- updated node example to be a properly formatted node module
 
 ## [v0.2.3-v0.2.4] - 2020-09-15
 

--- a/examples/node/README.md
+++ b/examples/node/README.md
@@ -1,13 +1,7 @@
 # ts_serialize NodeJS Example
 
-From this directory run
+To test the nodeJS package go to this directory and run:
 
 ```
-$ npm i @gamebridgeai/ts_serialize typescript @types/node
-```
-
-Then run 
-
-```
-$ npm test
+$ npm i && npm test
 ```

--- a/examples/node/package-lock.json
+++ b/examples/node/package-lock.json
@@ -1,0 +1,23 @@
+{
+  "name": "node_example",
+  "version": "0.2.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@gamebridgeai/ts_serialize": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@gamebridgeai/ts_serialize/-/ts_serialize-0.2.4.tgz",
+      "integrity": "sha512-SZjy+OIezypiaidQ5d/W7lbGLb+Fp1XNzyi4B3W4SawXZSxHmAuh6mvuNQMASVWvlIcdVLHB7APzY3HDhvfXRA=="
+    },
+    "@types/node": {
+      "version": "14.11.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.1.tgz",
+      "integrity": "sha512-oTQgnd0hblfLsJ6BvJzzSL+Inogp3lq9fGgqRkMB/ziKMgEUaFl801OncOzUmalfzt14N0oPHMK47ipl+wbTIw=="
+    },
+    "typescript": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
+      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg=="
+    }
+  }
+}

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -7,5 +7,10 @@
     "test": "tsc -p tsconfig.json && node node.js"
   },
   "author": "@gamebridgeai",
-  "license": "ISC"
+  "license": "ISC",
+  "dependencies": {
+    "@gamebridgeai/ts_serialize": "0.2.4",
+    "@types/node": "14.11.1",
+    "typescript": "4.0.3"
+  }
 }

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -9,7 +9,7 @@
   "author": "@gamebridgeai",
   "license": "ISC",
   "dependencies": {
-    "@gamebridgeai/ts_serialize": "0.2.4",
+    "@gamebridgeai/ts_serialize": "*",
     "@types/node": "14.11.1",
     "typescript": "4.0.3"
   }


### PR DESCRIPTION
## Fixes

- Sets up the node example project in a way developers can set up simply by running `npm i && npm test`
- Small improvements to nodeJS integration tests

## Description

Adds some small improvements to the nodeJS integration tests
Improvements to the setup of the nodeJS example project

## Proposed changes in this PR

- Updates `package.json` and adds a `package-lock.json` file to the nodeJS example project
- Small improvements to nodeJS build/test script

## Things to look at

- [x] Test coverage
- [x] Code Style
- [x] Documentation (READMEs etc)
