### PR TITLE
Serialized key function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added ability to use function as serialized key to transform property name
+
 ## [v0.3.0] - 2020-11-6
 
 ### Changed
+
 - updated node example to be a properly formatted node module
 - deno@1.5.1
 - std@0.76.0
@@ -22,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fixed #62
 
 ### Added
+
 - interface `tsTransformKey`
 - global transformKey processing and inheritance and overrides
 - TransformKey tests
@@ -30,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v0.2.3-v0.2.5] - 2020-09-15
 
 ### Changed
+
 - set up new deno deploy webhook
 
 ## [v0.1.1-v0.2.2] - 2020-09-14
@@ -38,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `/examples` for Node and Deno environments 
+- `/examples` for Node and Deno environments
 
 ### Changed
 

--- a/serialize_property.ts
+++ b/serialize_property.ts
@@ -12,12 +12,19 @@ import { SerializePropertyOptionsMap } from "./serialize_property_options_map.ts
 export const ERROR_MESSAGE_SYMBOL_PROPERTY_NAME =
   "The key name cannot be inferred from a symbol. A value for serializedName must be provided";
 
+/**
+ * Function to transform a property name into a serialized key programmatically
+ */
+export type ToSerializedKeyStrategy = ((
+  propertyName: string | symbol,
+) => string);
+
 /** string/symbol property name or options for (de)serializing values */
 export type SerializePropertyArgument =
   | string
-  | ((propertyName: string | symbol) => string)
+  | ToSerializedKeyStrategy
   | {
-    serializedKey?: string | ((propertyName: string | symbol) => string);
+    serializedKey?: string | ToSerializedKeyStrategy;
     fromJsonStrategy?:
       | FromJsonStrategy
       | (FromJsonStrategy | FromJsonStrategy[])[];

--- a/serialize_property.ts
+++ b/serialize_property.ts
@@ -66,36 +66,11 @@ export function SerializeProperty(
   decoratorArguments: SerializePropertyArgument = {},
 ): PropertyDecorator {
   return (target: unknown, propertyName: string | symbol) => {
-    let decoratorArgumentOptions: SerializePropertyArgumentObject;
-    if (typeof decoratorArguments === "string") {
-      decoratorArgumentOptions = { serializedKey: decoratorArguments };
-    } else if (typeof decoratorArguments == "function") {
-      decoratorArgumentOptions = {
-        serializedKey: decoratorArguments(propertyName),
-      };
-    } else {
-      // We can't use symbols as keys when serializing
-      // a serializedName must be provided if the property isn't a string
-      if (
-        !decoratorArguments.serializedKey &&
-        typeof propertyName === "symbol"
-      ) {
-        throw new Error(ERROR_MESSAGE_SYMBOL_PROPERTY_NAME);
-      }
-      if (typeof decoratorArguments.serializedKey === "function") {
-        decoratorArgumentOptions = {
-          serializedKey: decoratorArguments.serializedKey(propertyName),
-          fromJsonStrategy: decoratorArguments.fromJsonStrategy,
-          toJsonStrategy: decoratorArguments.toJsonStrategy,
-        };
-      } else {
-        decoratorArgumentOptions = {
-          // we can always define serializedKey as decoratorArguments.serializedKey will override this
-          serializedKey: (target as any).tsTransformKey(propertyName),
-          ...decoratorArguments,
-        };
-      }
-    }
+    const decoratorArgumentOptions = getDecoratorArgumentOptions(
+      decoratorArguments,
+      target,
+      propertyName,
+    );
 
     let serializablePropertiesMap = SERIALIZABLE_CLASS_MAP.get(target);
 
@@ -125,4 +100,48 @@ export function SerializeProperty(
       ),
     );
   };
+}
+
+/** Parses the arguments provided to SerializeProperty and 
+ * returns an object used to create a key mapping
+ */
+function getDecoratorArgumentOptions(
+  decoratorArguments: SerializePropertyArgument,
+  target: unknown,
+  propertyName: string | symbol,
+): SerializePropertyArgumentObject {
+  if (typeof decoratorArguments === "string") {
+    // Direct mapping to string
+    return { serializedKey: decoratorArguments };
+  } else if (typeof decoratorArguments === "function") {
+    // Property key transform function
+    return {
+      serializedKey: decoratorArguments(propertyName),
+    };
+  } else {
+    // We can't use symbols as keys when serializing
+    // a serializedName must be provided if the property isn't a string
+    if (
+      !decoratorArguments.serializedKey &&
+      typeof propertyName === "symbol"
+    ) {
+      throw new Error(ERROR_MESSAGE_SYMBOL_PROPERTY_NAME);
+    }
+    if (typeof decoratorArguments.serializedKey === "function") {
+      // Property key transform function with additional options
+      return {
+        serializedKey: decoratorArguments.serializedKey(propertyName),
+        fromJsonStrategy: decoratorArguments.fromJsonStrategy,
+        toJsonStrategy: decoratorArguments.toJsonStrategy,
+      };
+    } else {
+      // Use inherited tsTransformKey strategy (or default no change transform)
+      // to transform property key
+      return {
+        // we can always define serializedKey as decoratorArguments.serializedKey will override this
+        serializedKey: (target as any).tsTransformKey(propertyName),
+        ...decoratorArguments,
+      };
+    }
+  }
 }

--- a/serialize_property_test.ts
+++ b/serialize_property_test.ts
@@ -401,6 +401,24 @@ test({
 });
 
 test({
+  name: "Deserialize key function",
+  fn() {
+    class Test1 extends Serializable {
+      @SerializeProperty(
+        (
+          (propertyName) => "_" + (propertyName as string)
+        ),
+      )
+      serializeMe = "nice1";
+    }
+    assertEquals(
+      new Test1().fromJson(JSON.parse(`{"_serializeMe":"nice2"}`)).serializeMe,
+      `nice2`,
+    );
+  },
+});
+
+test({
   name: "Serialize key function object",
   fn() {
     class Test1 extends Serializable {
@@ -413,6 +431,21 @@ test({
     assertEquals(
       testObj.toJson(),
       `{"_serializeMe":"nice1"}`,
+    );
+  },
+});
+test({
+  name: "Deserialize key function object",
+  fn() {
+    class Test1 extends Serializable {
+      @SerializeProperty(
+        ({ serializedKey: (propertyName) => "_" + (propertyName as string) }),
+      )
+      serializeMe = "nice1";
+    }
+    assertEquals(
+      new Test1().fromJson(JSON.parse(`{"_serializeMe":"nice2"}`)).serializeMe,
+      `nice2`,
     );
   },
 });

--- a/serialize_property_test.ts
+++ b/serialize_property_test.ts
@@ -387,7 +387,7 @@ test({
     class Test1 extends Serializable {
       @SerializeProperty(
         (
-          (propertyName) => "_" + (propertyName as string)
+          (propertyName) => `_${String(propertyName)}`
         ),
       )
       serializeMe = "nice1";
@@ -406,7 +406,7 @@ test({
     class Test1 extends Serializable {
       @SerializeProperty(
         (
-          (propertyName) => "_" + (propertyName as string)
+          (propertyName) => `_${String(propertyName)}`
         ),
       )
       serializeMe = "nice1";
@@ -423,7 +423,7 @@ test({
   fn() {
     class Test1 extends Serializable {
       @SerializeProperty(
-        ({ serializedKey: (propertyName) => "_" + (propertyName as string) }),
+        ({ serializedKey: (propertyName) => `_${String(propertyName)}` }),
       )
       serializeMe = "nice1";
     }
@@ -439,7 +439,7 @@ test({
   fn() {
     class Test1 extends Serializable {
       @SerializeProperty(
-        ({ serializedKey: (propertyName) => "_" + (propertyName as string) }),
+        ({ serializedKey: (propertyName) => `_${String(propertyName)}` }),
       )
       serializeMe = "nice1";
     }

--- a/serialize_property_test.ts
+++ b/serialize_property_test.ts
@@ -380,3 +380,39 @@ test({
     );
   },
 });
+
+test({
+  name: "Serialize key function",
+  fn() {
+    class Test1 extends Serializable {
+      @SerializeProperty(
+        (
+          (propertyName) => "_" + (propertyName as string)
+        ),
+      )
+      serializeMe = "nice1";
+    }
+    const testObj = new Test1();
+    assertEquals(
+      testObj.toJson(),
+      `{"_serializeMe":"nice1"}`,
+    );
+  },
+});
+
+test({
+  name: "Serialize key function object",
+  fn() {
+    class Test1 extends Serializable {
+      @SerializeProperty(
+        ({ serializedKey: (propertyName) => "_" + (propertyName as string) }),
+      )
+      serializeMe = "nice1";
+    }
+    const testObj = new Test1();
+    assertEquals(
+      testObj.toJson(),
+      `{"_serializeMe":"nice1"}`,
+    );
+  },
+});


### PR DESCRIPTION
## Fixes

fixes #7 

## Description

Adds the ability to use a property key transform function as a serialized key

## Proposed changes in this PR

- Adds ability to pass a function that dynamically transforms the property key into a serialized key

## Things to look at

- [ ] Test coverage
- [ ] Code Style
- [ ] Documentation (READMEs etc)
