### PR TITLE
Fix type exports for deno 1.5.0 where isolatedModules is enabled by default

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -5,11 +5,11 @@
 /** property decorator */
 export { SerializeProperty } from "./serialize_property.ts";
 
+export type { FromJsonStrategy, ToJsonStrategy } from "./serializable.ts";
+
 /** abstract class and and compose strategy functions */
 export {
   Serializable,
-  FromJsonStrategy,
-  ToJsonStrategy,
   composeStrategy,
 } from "./serializable.ts";
 


### PR DESCRIPTION
## Description

deno 1.5.0 enables isolatedModules by default. Compilation was failing with:

`deno test` fails with:
```
error: TS1205 [ERROR]: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.
  FromJsonStrategy,
  ~~~~~~~~~~~~~~~~
    at file:///Users/msmith/git/ts_serialize/mod.ts:11:3

TS1205 [ERROR]: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.
  ToJsonStrategy,
  ~~~~~~~~~~~~~~
    at file:///Users/msmith/git/ts_serialize/mod.ts:12:3

Found 2 errors.
```

FromJsonStrategy and ToJsonStrategy are types. It seems exporting types has to be handled specially when isolatedModules is enabled.

- https://deno.land/manual/getting_started/typescript#code--no-checkcode-option
- https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-exports

## Proposed changes in this PR

Explicitly export the types with `export type`.

## Testing notes

If you upgrade to 1.5.0, run `deno test` on the develop branch, and hit the error, I find I had to wipe my TypeScript / deno cache (`rm -rf ~/Library/Caches/deno/gen/file/$HOME/git/`) in order for the fix to take effect.

## Things to look at

- [ ] Test coverage
- [ ] Code Style
- [ ] Documentation (READMEs etc)
