### PR TITLE
Add JSON types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+The input to fromJson() is now a JsonValue, enforcing basic JSON requirements:
+property values must be legal JSON values. This is meant to allow the
+compiler to flag accidental deserializations of already-deserialized objects.
 
 ### Added
 
-## [v0.3.0] - 2020-11-6
+## [v0.3.0] - 2020-11-06
 
 ### Changed
 - updated node example to be a properly formatted node module

--- a/from_json/as.ts
+++ b/from_json/as.ts
@@ -6,7 +6,7 @@ import { FromJsonStrategy, Serializable } from "../serializable.ts";
 export function fromJsonAs<T>(
   type: T & { new (): Serializable },
 ): FromJsonStrategy {
-  return value => {
+  return (value) => {
     if (Array.isArray(value)) {
       return value.map((item) => new type().fromJson(item));
     }

--- a/from_json/as.ts
+++ b/from_json/as.ts
@@ -11,10 +11,10 @@ import {
 export function fromJsonAs<T>(
   type: T & { new (): Serializable },
 ): FromJsonStrategy {
-  return (value: T) => {
+  return (value: JsonValue) => {
     if (Array.isArray(value)) {
-      return value.map((item) => new type().fromJson(item));
+      return value.map((item) => new type().fromJson(item as JsonObject));
     }
-    return new type().fromJson(value);
+    return new type().fromJson(value as JsonObject);
   };
 }

--- a/from_json/as.ts
+++ b/from_json/as.ts
@@ -2,8 +2,6 @@
 
 import {
   FromJsonStrategy,
-  JsonObject,
-  JsonValue,
   Serializable,
 } from "../serializable.ts";
 
@@ -11,10 +9,10 @@ import {
 export function fromJsonAs<T>(
   type: T & { new (): Serializable },
 ): FromJsonStrategy {
-  return (value: JsonValue) => {
+  return value => {
     if (Array.isArray(value)) {
-      return value.map((item) => new type().fromJson(item as JsonObject));
+      return value.map((item) => new type().fromJson(item));
     }
-    return new type().fromJson(value as JsonObject);
+    return new type().fromJson(value);
   };
 }

--- a/from_json/as.ts
+++ b/from_json/as.ts
@@ -1,9 +1,6 @@
 // Copyright 2018-2020 Gamebridge.ai authors. All rights reserved. MIT license.
 
-import {
-  FromJsonStrategy,
-  Serializable,
-} from "../serializable.ts";
+import { FromJsonStrategy, Serializable } from "../serializable.ts";
 
 /** revive data using `fromJson` on a subclass type */
 export function fromJsonAs<T>(

--- a/from_json/as.ts
+++ b/from_json/as.ts
@@ -1,10 +1,15 @@
 // Copyright 2018-2020 Gamebridge.ai authors. All rights reserved. MIT license.
 
-import { FromJsonStrategy, Serializable } from "../serializable.ts";
+import {
+  FromJsonStrategy,
+  JsonObject,
+  JsonValue,
+  Serializable,
+} from "../serializable.ts";
 
 /** revive data using `fromJson` on a subclass type */
 export function fromJsonAs<T>(
   type: T & { new (): Serializable },
 ): FromJsonStrategy {
-  return (value: T) => new type().fromJson(value);
+  return (value: JsonValue) => new type().fromJson(value as JsonObject);
 }

--- a/from_json/as_test.ts
+++ b/from_json/as_test.ts
@@ -13,8 +13,8 @@ test({
       test = true;
     }
     const testObj = new Test();
-    assertEquals(fromJsonAs(Test)(testObj).test, testObj.test);
-    assert(fromJsonAs(Test)(testObj) instanceof Test);
+    assertEquals(fromJsonAs(Test)({ test: true }).test, testObj.test);
+    assert(fromJsonAs(Test)({ test: true }) instanceof Test);
   },
 });
 

--- a/from_json/date.ts
+++ b/from_json/date.ts
@@ -1,10 +1,10 @@
 // Copyright 2018-2020 Gamebridge.ai authors. All rights reserved. MIT license.
 
-import { FromJsonStrategy } from "../serializable.ts";
+import { FromJsonStrategy, JsonValue } from "../serializable.ts";
 
 /** allows authors to pass a regex to parse as a date */
 export function createDateStrategy(regex: RegExp): FromJsonStrategy {
-  return (value: any): any | Date => {
+  return (value: JsonValue): any | Date => {
     return typeof value === "string" && regex.exec(value)
       ? new Date(value)
       : value;

--- a/serializable.ts
+++ b/serializable.ts
@@ -34,10 +34,9 @@ export abstract class Serializable {
   public toJson(): string {
     return toJson(this);
   }
-  public fromJson(): this;
   public fromJson(json: string): this;
   public fromJson(json: JsonObject): this;
-  public fromJson(json: string | JsonObject = {}): this {
+  public fromJson(json: string | JsonObject): this {
     return fromJson(this, json);
   }
 }

--- a/serializable.ts
+++ b/serializable.ts
@@ -35,8 +35,8 @@ export abstract class Serializable {
     return toJson(this);
   }
   public fromJson(json: string): this;
-  public fromJson(json: JsonObject): this;
-  public fromJson(json: string | JsonObject): this {
+  public fromJson(json: JsonValue): this;
+  public fromJson(json: string | JsonValue): this {
     return fromJson(this, json);
   }
 }
@@ -161,16 +161,16 @@ function toJson<T>(context: T): string {
 /** Convert from object/string to mapped object on the context */
 function fromJson<T>(context: Serializable, json: string): T;
 
-function fromJson<T>(context: Serializable, json: JsonObject): T;
+function fromJson<T>(context: Serializable, json: JsonValue): T;
 
 function fromJson<T>(
   context: Serializable,
-  json: string | JsonObject,
+  json: string | JsonValue,
 ): T;
 
 function fromJson<T>(
   context: Serializable,
-  json: string | JsonObject,
+  json: string | JsonValue,
 ): T {
   const serializablePropertyMap = SERIALIZABLE_CLASS_MAP.get(
     context?.constructor?.prototype,

--- a/serialize_property_test.ts
+++ b/serialize_property_test.ts
@@ -7,7 +7,7 @@ import {
   fail,
   test,
 } from "./test_deps.ts";
-import { JsonObject, JsonValue, Serializable } from "./serializable.ts";
+import { Serializable } from "./serializable.ts";
 import {
   ERROR_MESSAGE_SYMBOL_PROPERTY_NAME,
   SerializeProperty,
@@ -216,8 +216,8 @@ test({
     }
     class Test extends Serializable {
       @SerializeProperty({
-        fromJsonStrategy: (v: JsonValue) =>
-          new OtherClass().fromJson(v as JsonObject),
+        fromJsonStrategy: v =>
+          new OtherClass().fromJson(v),
       })
       array!: OtherClass[];
     }
@@ -350,7 +350,7 @@ test({
       @SerializeProperty({
         serializedKey: "serialize_me_2",
         fromJsonStrategy: json =>
-          new Test1().fromJson(json as JsonObject),
+          new Test1().fromJson(json),
       })
       nested!: Test1;
     }

--- a/serialize_property_test.ts
+++ b/serialize_property_test.ts
@@ -349,8 +349,7 @@ test({
     class Test2 extends Serializable {
       @SerializeProperty({
         serializedKey: "serialize_me_2",
-        fromJsonStrategy: json =>
-          new Test1().fromJson(json),
+        fromJsonStrategy: json => new Test1().fromJson(json),
       })
       nested!: Test1;
     }

--- a/serialize_property_test.ts
+++ b/serialize_property_test.ts
@@ -7,7 +7,7 @@ import {
   assertStrictEquals,
   fail,
 } from "./test_deps.ts";
-import { Serializable } from "./serializable.ts";
+import { JsonObject, JsonValue, Serializable } from "./serializable.ts";
 import {
   SerializeProperty,
   ERROR_MESSAGE_SYMBOL_PROPERTY_NAME,
@@ -216,7 +216,8 @@ test({
     }
     class Test extends Serializable {
       @SerializeProperty({
-        fromJsonStrategy: (v: OtherClass) => new OtherClass().fromJson(v),
+        fromJsonStrategy: (v: JsonValue) =>
+          new OtherClass().fromJson(v as JsonObject),
       })
       array!: OtherClass[];
     }
@@ -348,7 +349,8 @@ test({
     class Test2 extends Serializable {
       @SerializeProperty({
         serializedKey: "serialize_me_2",
-        fromJsonStrategy: (json) => new Test1().fromJson(json),
+        fromJsonStrategy: (json: JsonValue) =>
+          new Test1().fromJson(json as JsonObject),
       })
       nested!: Test1;
     }

--- a/serialize_property_test.ts
+++ b/serialize_property_test.ts
@@ -216,8 +216,7 @@ test({
     }
     class Test extends Serializable {
       @SerializeProperty({
-        fromJsonStrategy: v =>
-          new OtherClass().fromJson(v),
+        fromJsonStrategy: (v) => new OtherClass().fromJson(v),
       })
       array!: OtherClass[];
     }
@@ -349,7 +348,7 @@ test({
     class Test2 extends Serializable {
       @SerializeProperty({
         serializedKey: "serialize_me_2",
-        fromJsonStrategy: json => new Test1().fromJson(json),
+        fromJsonStrategy: (json) => new Test1().fromJson(json),
       })
       nested!: Test1;
     }

--- a/serialize_property_test.ts
+++ b/serialize_property_test.ts
@@ -349,7 +349,7 @@ test({
     class Test2 extends Serializable {
       @SerializeProperty({
         serializedKey: "serialize_me_2",
-        fromJsonStrategy: (json: JsonValue) =>
+        fromJsonStrategy: json =>
           new Test1().fromJson(json as JsonObject),
       })
       nested!: Test1;

--- a/to_json/recursive.ts
+++ b/to_json/recursive.ts
@@ -1,8 +1,8 @@
 // Copyright 2018-2020 Gamebridge.ai authors. All rights reserved. MIT license.
 
-import { toPojo, Serializable } from "../serializable.ts";
+import { toPojo, Serializable, JsonObject } from "../serializable.ts";
 
 /** Recursively serialize a serializable class */
-export function recursiveToJson(value: Serializable): any {
+export function recursiveToJson(value: Serializable): JsonObject {
   return toPojo(value);
 }


### PR DESCRIPTION
## Fixes

#59 - JsonNode type

## Description

Define explicit types for legal plain JSON values to avoid double-deserialization shenanigans.

Fixes #59.

## Proposed changes in this PR

Adds JsonValue and JsonObject types to make ToJsonStrategy and FromJsonStrategy more specific.

## Things to look at

- [ ] Test coverage
- [ ] Code Style
- [ ] Documentation (READMEs etc)
