### PR TITLE
tsTransformKey functionality

### DIFF
--- a/.github/workflows/scripts/npm_release_files/ts_serialize.d.ts
+++ b/.github/workflows/scripts/npm_release_files/ts_serialize.d.ts
@@ -1,6 +1,16 @@
 declare module "@gamebridgeai/ts_serialize" {
+  /** to be implemented by external authors on their models  */
+  export interface TransformKey {
+    /** a function that will be called against
+   * every property key transforming the key
+   * with the provided function
+   */
+    tsTransformKey(key: string): string;
+  }
+
   /** Adds methods for serialization */
   export abstract class Serializable {
+    public tsTransformKey?(key: string): string;
     public toJson(): string;
     public fromJson(): this;
     public fromJson(json: string): this;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - interface `tsTransformKey`
 - global transformKey processing and inheritance and overrides
-- TransformKey tests
+- TransformKey tests    
 
 ## [v0.2.3-v0.2.5] - 2020-09-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - std@0.76.0
 - fmt changes with deno upgrade
 
-## [v0.2.3-v0.2.4] - 2020-09-15
+### Added
+- interface `tsTransformKey`
+- global transformKey processing and inheritance and overrides
+- TransformKey tests
+
+## [v0.2.3-v0.2.5] - 2020-09-15
 
 ### Changed
 - set up new deno deploy webhook
@@ -42,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- released privately as a part of a demo
+- released as a part of a deno
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- released as a part of a deno
+- released privately as a part of a demo
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - interface `tsTransformKey`
 - global transformKey processing and inheritance and overrides
-- TransformKey tests    
+- TransformKey tests
+- new examples for node and deno
 
 ## [v0.2.3-v0.2.5] - 2020-09-15
 

--- a/README.md
+++ b/README.md
@@ -104,11 +104,6 @@ class TestTransformKey3 extends TestTransformKey2 {
   public test3 = "test3";
 }
 
-assertEquals(new TestTransformKey2().toJson(), `{"__test2__":"test2"}`);
-assertEquals(
-  new TestTransformKey2().fromJson({ __test2__: "changed" }).test2,
-  `changed`,
-);
 assertEquals(
   new TestTransformKey3().toJson(),
   `{"__test2__":"test2","__test3__":"test3"}`,
@@ -145,20 +140,6 @@ class TestTransformKey4 extends TestTransformKey3 {
   @SerializeProperty()
   public test4 = "test4";
 }
-
-assertEquals(new TestTransformKey2().toJson(), `{"__test2__":"test2"}`);
-assertEquals(
-  new TestTransformKey2().fromJson({ __test2__: "changed" }).test2,
-  `changed`,
-);
-assertEquals(
-  new TestTransformKey3().toJson(),
-  `{"__test2__":"test2","--test3--":"test3"}`,
-);
-assertEquals(
-  new TestTransformKey3().fromJson({ "--test3--": "changed" }).test3,
-  `changed`,
-);
 assertEquals(
   new TestTransformKey4().toJson(),
   `{"__test2__":"test2","--test3--":"test3","--test4--":"test4"}`,
@@ -229,6 +210,28 @@ class Test extends Serializable {
 
 const testObj = new Test().fromJson(`{"big_int":"9007199254740991"}`);
 assertEquals(testObj.bigInt.toString(), "9007199254740991");
+```
+
+#### Multiple strategy functions
+
+`toJsonStrategy` and `fromJsonStrategy` can use `composeStrategy` to build out
+strategies with multiple functions.
+
+```ts
+const addWord = (word: string) => (v: string) => `${v} ${word}`;
+const shout = (v: string) => `${v}!!!`;
+
+class Test extends Serializable {
+  @SerializeProperty({
+    fromJsonStrategy: composeStrategy(addWord("World"), shout),
+  })
+  property!: string;
+}
+
+assertEquals(
+  new Test().fromJson(`{"property":"Hello"}`).property,
+  "Hello World!!!"
+);
 ```
 
 #### Dates
@@ -332,28 +335,6 @@ class Test2 extends Serializable {
 const testObj = new Test2();
 testObj.fromJson(`{"serialize_me_2":{"serialize_me_1":"custom value"}}`);
 assertEquals(testObj.nested.serializeMe, "custom value");
-```
-
-#### Multiple strategy functions
-
-`toJsonStrategy` and `fromJsonStrategy` can use `composeStrategy` to build out
-strategies with multiple functions.
-
-```ts
-const addWord = (word: string) => (v: string) => `${v} ${word}`;
-const shout = (v: string) => `${v}!!!`;
-
-class Test extends Serializable {
-  @SerializeProperty({
-    fromJsonStrategy: composeStrategy(addWord("World"), shout),
-  })
-  property!: string;
-}
-
-assertEquals(
-  new Test().fromJson(`{"property":"Hello"}`).property,
-  "Hello World!!!"
-);
 ```
 
 ## Built With

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ assertEquals(
 ```
 
 `tsTransformKey` is an efficient way to deal with 
-snake_case -> camelCase conversions.
+camelCase to snake_case conversions.
 
 ### Advanced
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ and use the `SerializeProperty` decorator on any properties you want serialized.
 Passing a string as an argument to `SerializeProperty` causes the property to use
 that name as the key when serialized.
 
+`SerializeProperty` also excepts an options object with the properties:
+
+- `serializedKey` (Optional) {string} - Used as the key in the serialized object
+- `toJsonStrategy` (Optional) {ToJsonStrategy} - Function or `ToJsonStrategy` used when serializing
+- `fromJsonStrategy` (Optional) {FromJsonStrategy} - Function or `FromJsonStrategy` used when deserializing
+
 ```ts
 class Test extends Serializable {
   @SerializeProperty()
@@ -57,13 +63,151 @@ assertEquals(testObj.notSerialized, "changed");
 assertEquals(testObj.toJson(), `{"propertyOne":"From","property_two":"Json!"}`);
 ```
 
+#### Transforming Keys
+
+`Serializable` has a optional function `tsTransformKey(key: string): string`. This function 
+can be provided to change all the keys without having to specify the change for each property.
+
+```ts
+class TestTransformKey extends Serializable implements TransformKey {
+  public tsTransformKey(key: string): string {
+    return `__${key}__`;
+  }
+
+  @SerializeProperty()
+  public test = "test";
+}
+
+assertEquals(new TestTransformKey().toJson(), `{"__test__":"test"}`);
+assertEquals(
+  new TestTransformKey().fromJson({ __test__: "changed" }).test,
+  `changed`,
+);
+```
+
+`tsTransformKey` will be inherited by children
+
+```ts
+class TestTransformKey extends Serializable implements TransformKey {
+  public tsTransformKey(key: string): string {
+    return `__${key}__`;
+  }
+}
+
+class TestTransformKey2 extends TestTransformKey {
+  @SerializeProperty()
+  public test2 = "test2";
+}
+
+class TestTransformKey3 extends TestTransformKey2 {
+  @SerializeProperty()
+  public test3 = "test3";
+}
+
+assertEquals(new TestTransformKey2().toJson(), `{"__test2__":"test2"}`);
+assertEquals(
+  new TestTransformKey2().fromJson({ __test2__: "changed" }).test2,
+  `changed`,
+);
+assertEquals(
+  new TestTransformKey3().toJson(),
+  `{"__test2__":"test2","__test3__":"test3"}`,
+);
+assertEquals(
+  new TestTransformKey3().fromJson({ __test3__: "changed" }).test3,
+  `changed`,
+);
+```
+
+Children can also override their parent `tsTransformKey` function.
+
+```ts
+class TestTransformKey extends Serializable implements TransformKey {
+  public tsTransformKey(key: string): string {
+    return `__${key}__`;
+  }
+}
+
+class TestTransformKey2 extends TestTransformKey {
+  @SerializeProperty()
+  public test2 = "test2";
+}
+
+class TestTransformKey3 extends TestTransformKey2 implements TransformKey {
+  public tsTransformKey(key: string): string {
+    return `--${key}--`;
+  }
+  @SerializeProperty()
+  public test3 = "test3";
+}
+
+class TestTransformKey4 extends TestTransformKey3 {
+  @SerializeProperty()
+  public test4 = "test4";
+}
+
+assertEquals(new TestTransformKey2().toJson(), `{"__test2__":"test2"}`);
+assertEquals(
+  new TestTransformKey2().fromJson({ __test2__: "changed" }).test2,
+  `changed`,
+);
+assertEquals(
+  new TestTransformKey3().toJson(),
+  `{"__test2__":"test2","--test3--":"test3"}`,
+);
+assertEquals(
+  new TestTransformKey3().fromJson({ "--test3--": "changed" }).test3,
+  `changed`,
+);
+assertEquals(
+  new TestTransformKey4().toJson(),
+  `{"__test2__":"test2","--test3--":"test3","--test4--":"test4"}`,
+);
+assertEquals(
+  new TestTransformKey4().fromJson({ "--test4--": "changed" }).test4,
+  `changed`,
+);
+```
+
+If `tsTransformKey` is implemented and `SerializeProperty` is provided a 
+`serializedKey` option, it will override the `tsTransformKey` function
+
+```ts
+class TestTransformKey extends Serializable implements TransformKey {
+  public tsTransformKey(key: string): string {
+    return `__${key}__`;
+  }
+}
+
+class TestTransformKey2 extends TestTransformKey {
+  @SerializeProperty()
+  public test2 = "test2";
+
+  @SerializeProperty("changed")
+  public changeMe = "change me";
+
+  @SerializeProperty({ serializedKey: "changed2" })
+  public changeMe2 = "change me2";
+}
+
+assertEquals(
+  new TestTransformKey2().toJson(),
+  `{"__test2__":"test2","changed":"change me","changed2":"change me2"}`,
+);
+assertEquals(
+  new TestTransformKey2().fromJson({ changed: "changed" }).changeMe,
+  `changed`,
+);
+assertEquals(
+  new TestTransformKey2().fromJson({ changed2: "changed" }).changeMe2,
+  `changed`,
+);
+```
+
+`tsTransformKey` is an efficient way to deal with 
+snake_case -> camelCase conversions.
+
 ### Advanced
-
-`SerializeProperty` also excepts an options object with the properties:
-
-- `serializedKey` (Optional) {string} - Used as the key in the serialized object
-- `toJsonStrategy` (Optional) {ToJsonStrategy} - Function or `ToJsonStrategy` used when serializing
-- `fromJsonStrategy` (Optional) {FromJsonStrategy} - Function or `FromJsonStrategy` used when deserializing
 
 #### Strategies
 

--- a/examples/deno/deno.ts
+++ b/examples/deno/deno.ts
@@ -8,6 +8,7 @@ import {
   Serializable,
   SerializeProperty,
   ToJsonStrategy,
+  TransformKey,
 } from "./deps.ts";
 
 function assert(boolean: boolean, msg?: string): void {
@@ -100,3 +101,51 @@ assert(test.isoDate instanceof Date, "isoDate instanceof");
 assert(test.isoDate.getFullYear() === 2020, "isoDate.getFullYear90");
 assert(test.createDate instanceof Date, "createDate instanceof");
 assert(test.createDate.getFullYear() === 2099, "createDate.getFullYear()");
+
+class TestTransformKey extends Serializable implements TransformKey {
+  public tsTransformKey(key: string): string {
+    return `__${key}__`;
+  }
+}
+
+class TestTransformKey2 extends TestTransformKey {
+  @SerializeProperty()
+  public test2 = "test2";
+}
+
+class TestTransformKey3 extends TestTransformKey2 implements TransformKey {
+  public tsTransformKey(key: string): string {
+    return `--${key}--`;
+  }
+  @SerializeProperty()
+  public test3 = "test3";
+}
+
+class TestTransformKey4 extends TestTransformKey3 {
+  @SerializeProperty()
+  public test4 = "test4";
+}
+
+assert(new TestTransformKey2().toJson() === `{"__test2__":"test2"}`);
+assert(
+  new TestTransformKey2().fromJson({ __test2__: "changed" }).test2 ===
+    `changed`,
+);
+
+assert(
+  new TestTransformKey3().toJson() ===
+    `{"__test2__":"test2","--test3--":"test3"}`,
+);
+assert(
+  new TestTransformKey3().fromJson({ "--test3--": "changed" }).test3 ===
+    `changed`,
+);
+
+assert(
+  new TestTransformKey4().toJson() ===
+    `{"__test2__":"test2","--test3--":"test3","--test4--":"test4"}`,
+);
+assert(
+  new TestTransformKey4().fromJson({ "--test4--": "changed" }).test4 ===
+    `changed`,
+);

--- a/examples/deno/deps.ts
+++ b/examples/deno/deps.ts
@@ -7,5 +7,6 @@ export {
   Serializable,
   SerializeProperty,
   ToJsonStrategy,
+  TransformKey,
 } from "https://deno.land/x/ts_serialize/mod.ts";
 export { readJson } from "https://deno.land/std@0.68.0/fs/mod.ts";

--- a/examples/node/node.ts
+++ b/examples/node/node.ts
@@ -9,6 +9,7 @@ import {
   Serializable,
   SerializeProperty,
   ToJsonStrategy,
+  TransformKey,
 } from "@gamebridgeai/ts_serialize";
 import toJsonFixture from "../fixtures/to.json";
 import fromJsonFixture from "../fixtures/from.json";
@@ -95,3 +96,51 @@ assert(test.isoDate instanceof Date, "isoDate instanceof");
 assert(test.isoDate.getFullYear() === 2020, "isoDate.getFullYear90");
 assert(test.createDate instanceof Date, "createDate instanceof");
 assert(test.createDate.getFullYear() === 2099, "createDate.getFullYear()");
+
+class TestTransformKey extends Serializable implements TransformKey {
+  public tsTransformKey(key: string): string {
+    return `__${key}__`;
+  }
+}
+
+class TestTransformKey2 extends TestTransformKey {
+  @SerializeProperty()
+  public test2 = "test2";
+}
+
+class TestTransformKey3 extends TestTransformKey2 implements TransformKey {
+  public tsTransformKey(key: string): string {
+    return `--${key}--`;
+  }
+  @SerializeProperty()
+  public test3 = "test3";
+}
+
+class TestTransformKey4 extends TestTransformKey3 {
+  @SerializeProperty()
+  public test4 = "test4";
+}
+
+assert(new TestTransformKey2().toJson() === `{"__test2__":"test2"}`);
+assert(
+  new TestTransformKey2().fromJson({ __test2__: "changed" }).test2 ===
+    `changed`,
+);
+
+assert(
+  new TestTransformKey3().toJson() ===
+    `{"__test2__":"test2","--test3--":"test3"}`,
+);
+assert(
+  new TestTransformKey3().fromJson({ "--test3--": "changed" }).test3 ===
+    `changed`,
+);
+
+assert(
+  new TestTransformKey4().toJson() ===
+    `{"__test2__":"test2","--test3--":"test3","--test4--":"test4"}`,
+);
+assert(
+  new TestTransformKey4().fromJson({ "--test4--": "changed" }).test4 ===
+    `changed`,
+);

--- a/mod.ts
+++ b/mod.ts
@@ -6,7 +6,11 @@
 export { SerializeProperty } from "./serialize_property.ts";
 
 /** types, isolatedModules requires this to be `export type ...` */
-export type { FromJsonStrategy, ToJsonStrategy } from "./serializable.ts";
+export type {
+  FromJsonStrategy,
+  ToJsonStrategy,
+  TransformKey,
+} from "./serializable.ts";
 
 /** abstract class and and compose strategy functions */
 export { composeStrategy, Serializable } from "./serializable.ts";

--- a/serializable.ts
+++ b/serializable.ts
@@ -4,8 +4,15 @@ import { SerializePropertyOptionsMap } from "./serialize_property_options_map.ts
 import { defaultToJson } from "./to_json/default.ts";
 import { recursiveToJson } from "./to_json/recursive.ts";
 
+export declare interface TransformKey {
+  tsTransformKey(key: string): string;
+}
+
 /** Adds methods for serialization */
 export abstract class Serializable {
+  public tsTransformKey?(key: string): string {
+    return key;
+  }
   public toJson(): string {
     return toJson(this);
   }
@@ -80,8 +87,8 @@ const ERROR_MESSAGE_MISSING_PROPERTIES_MAP =
   "Unable to load serializer properties for the given context";
 
 /** Converts to object using mapped keys */
-export function toPojo<T>(
-  context: Record<keyof T, unknown>,
+export function toPojo(
+  context: any,
 ): Record<string, unknown> {
   const serializablePropertyMap = SERIALIZABLE_CLASS_MAP.get(
     context?.constructor?.prototype,
@@ -102,7 +109,7 @@ export function toPojo<T>(
     } of serializablePropertyMap.propertyOptions()
   ) {
     // Assume that key is always a string, a check is done earlier in SerializeProperty
-    const value = context[propertyKey as keyof T];
+    const value = context[String(propertyKey)];
 
     // If the value is serializable then use the recursive replacer
     if (

--- a/serializable.ts
+++ b/serializable.ts
@@ -4,12 +4,18 @@ import { SerializePropertyOptionsMap } from "./serialize_property_options_map.ts
 import { defaultToJson } from "./to_json/default.ts";
 import { recursiveToJson } from "./to_json/recursive.ts";
 
+/** to be implemented by external authors on their models  */
 export declare interface TransformKey {
+  /** a function that will be called against
+   * every property key transforming the key
+   * with the provided function
+   */
   tsTransformKey(key: string): string;
 }
 
 /** Adds methods for serialization */
 export abstract class Serializable {
+  /** the default transform functionality */
   public tsTransformKey?(key: string): string {
     return key;
   }

--- a/serializable.ts
+++ b/serializable.ts
@@ -109,7 +109,7 @@ export function toPojo(
     } of serializablePropertyMap.propertyOptions()
   ) {
     // Assume that key is always a string, a check is done earlier in SerializeProperty
-    const value = context[String(propertyKey)];
+    const value = context[propertyKey as string];
 
     // If the value is serializable then use the recursive replacer
     if (

--- a/serializable_test.ts
+++ b/serializable_test.ts
@@ -1,7 +1,8 @@
 // Copyright 2018-2020 Gamebridge.ai authors. All rights reserved. MIT license.
 
 import { assert, assertEquals, test } from "./test_deps.ts";
-import { composeStrategy, Serializable } from "./serializable.ts";
+import { composeStrategy, Serializable, TransformKey } from "./serializable.ts";
+import { SerializeProperty } from "./serialize_property.ts";
 
 test({
   name: "adds methods to extended classes",
@@ -29,5 +30,130 @@ test({
       shout,
     );
     assertEquals(strategy("Hello"), "Hello World!!!");
+  },
+});
+
+test({
+  name: "does not run TransformKey if not implemented",
+  fn() {
+    class TestTransformKey extends Serializable {
+      @SerializeProperty()
+      public test = "test";
+    }
+
+    assertEquals(new TestTransformKey().toJson(), `{"test":"test"}`);
+    assertEquals(
+      new TestTransformKey().fromJson({ test: "changed" }).test,
+      `changed`,
+    );
+  },
+});
+
+test({
+  name: "runs TransformKey without implementation declaration",
+  fn() {
+    class TestTransformKey extends Serializable {
+      public tsTransformKey(key: string): string {
+        return `__${key}__`;
+      }
+
+      @SerializeProperty()
+      public test = "test";
+    }
+
+    assertEquals(new TestTransformKey().toJson(), `{"__test__":"test"}`);
+    assertEquals(
+      new TestTransformKey().fromJson({ __test__: "changed" }).test,
+      `changed`,
+    );
+  },
+});
+
+test({
+  name: "implements TransformKey to children",
+  fn() {
+    class TestTransformKey extends Serializable implements TransformKey {
+      public tsTransformKey(key: string): string {
+        return `__${key}__`;
+      }
+    }
+
+    class TestTransformKey2 extends TestTransformKey {
+      @SerializeProperty()
+      public test2 = "test2";
+    }
+
+    class TestTransformKey3 extends TestTransformKey2 {
+      @SerializeProperty()
+      public test3 = "test3";
+    }
+
+    assertEquals(new TestTransformKey2().toJson(), `{"__test2__":"test2"}`);
+    assertEquals(
+      new TestTransformKey2().fromJson({ __test2__: "changed" }).test2,
+      `changed`,
+    );
+
+    assertEquals(
+      new TestTransformKey3().toJson(),
+      `{"__test2__":"test2","__test3__":"test3"}`,
+    );
+    assertEquals(
+      new TestTransformKey3().fromJson({ __test3__: "changed" }).test3,
+      `changed`,
+    );
+  },
+});
+
+test({
+  name: "implements TransformKey to children and children can change",
+  fn() {
+    class TestTransformKey extends Serializable implements TransformKey {
+      public tsTransformKey(key: string): string {
+        return `__${key}__`;
+      }
+    }
+
+    class TestTransformKey2 extends TestTransformKey {
+      @SerializeProperty()
+      public test2 = "test2";
+    }
+
+    class TestTransformKey3 extends TestTransformKey2 implements TransformKey {
+      public tsTransformKey(key: string): string {
+        return `--${key}--`;
+      }
+      @SerializeProperty()
+      public test3 = "test3";
+    }
+
+    class TestTransformKey4 extends TestTransformKey3 {
+      @SerializeProperty()
+      public test4 = "test4";
+    }
+
+    assertEquals(new TestTransformKey2().toJson(), `{"__test2__":"test2"}`);
+    assertEquals(
+      new TestTransformKey2().fromJson({ __test2__: "changed" }).test2,
+      `changed`,
+    );
+
+    assertEquals(
+      new TestTransformKey3().toJson(),
+      `{"__test2__":"test2","--test3--":"test3"}`,
+    );
+    assertEquals(
+      new TestTransformKey3().fromJson({ "--test3--": "changed" }).test3,
+      `changed`,
+    );
+
+    assertEquals(
+      new TestTransformKey4().toJson(),
+      `{"__test2__":"test2","--test3--":"test3","--test4--":"test4"}`,
+    );
+    assertEquals(
+      new TestTransformKey4().fromJson({ "--test4--": "changed" }).test4,
+      `changed`,
+    );
   },
 });

--- a/serializable_test.ts
+++ b/serializable_test.ts
@@ -157,3 +157,59 @@ test({
     );
   },
 });
+
+test({
+  name: "implements TransformKey but respects override as string",
+  fn() {
+    class TestTransformKey extends Serializable implements TransformKey {
+      public tsTransformKey(key: string): string {
+        return `__${key}__`;
+      }
+    }
+
+    class TestTransformKey2 extends TestTransformKey {
+      @SerializeProperty()
+      public test2 = "test2";
+
+      @SerializeProperty("changed")
+      public changeMe = "change me";
+    }
+
+    assertEquals(
+      new TestTransformKey2().toJson(),
+      `{"__test2__":"test2","changed":"change me"}`,
+    );
+    assertEquals(
+      new TestTransformKey2().fromJson({ changed: "changed" }).changeMe,
+      `changed`,
+    );
+  },
+});
+
+test({
+  name: "implements TransformKey but respects override as property",
+  fn() {
+    class TestTransformKey extends Serializable implements TransformKey {
+      public tsTransformKey(key: string): string {
+        return `__${key}__`;
+      }
+    }
+
+    class TestTransformKey2 extends TestTransformKey {
+      @SerializeProperty()
+      public test2 = "test2";
+
+      @SerializeProperty({ serializedKey: "changed" })
+      public changeMe = "change me";
+    }
+
+    assertEquals(
+      new TestTransformKey2().toJson(),
+      `{"__test2__":"test2","changed":"change me"}`,
+    );
+    assertEquals(
+      new TestTransformKey2().fromJson({ changed: "changed" }).changeMe,
+      `changed`,
+    );
+  },
+});

--- a/serialize_property.ts
+++ b/serialize_property.ts
@@ -57,7 +57,7 @@ export function SerializeProperty(
 export function SerializeProperty(
   decoratorArguments: SerializePropertyArgument = {},
 ): PropertyDecorator {
-  return (target: any, propertyName: string | symbol) => {
+  return (target: unknown, propertyName: string | symbol) => {
     let decoratorArgumentOptions: SerializePropertyArgumentObject;
 
     if (typeof decoratorArguments === "string") {
@@ -72,9 +72,10 @@ export function SerializeProperty(
         throw new Error(ERROR_MESSAGE_SYMBOL_PROPERTY_NAME);
       }
 
+      // get current class or parent class function
       const transformKeyFunction =
         Object.prototype.hasOwnProperty.call(target, "tsTransformKey")
-          ? target.tsTransformKey
+          ? (target as any).tsTransformKey
           : Object.getPrototypeOf(target).tsTransformKey;
 
       decoratorArgumentOptions = {

--- a/serialize_property.ts
+++ b/serialize_property.ts
@@ -73,10 +73,7 @@ export function SerializeProperty(
       }
 
       // get current class or parent class function
-      const transformKeyFunction =
-        Object.prototype.hasOwnProperty.call(target, "tsTransformKey")
-          ? (target as any).tsTransformKey
-          : Object.getPrototypeOf(target).tsTransformKey;
+      const transformKeyFunction = (target as any).tsTransformKey;
 
       decoratorArgumentOptions = {
         serializedKey: transformKeyFunction(propertyName),

--- a/serialize_property.ts
+++ b/serialize_property.ts
@@ -72,11 +72,9 @@ export function SerializeProperty(
         throw new Error(ERROR_MESSAGE_SYMBOL_PROPERTY_NAME);
       }
 
-      // get current class or parent class function
-      const transformKeyFunction = (target as any).tsTransformKey;
-
       decoratorArgumentOptions = {
-        serializedKey: transformKeyFunction(propertyName),
+        // we can always define serializedKey as decoratorArguments.serializedKey will override this
+        serializedKey: (target as any).tsTransformKey(propertyName),
         ...decoratorArguments,
       };
     }

--- a/serialize_property.ts
+++ b/serialize_property.ts
@@ -57,7 +57,7 @@ export function SerializeProperty(
 export function SerializeProperty(
   decoratorArguments: SerializePropertyArgument = {},
 ): PropertyDecorator {
-  return (target: unknown, propertyName: string | symbol) => {
+  return (target: any, propertyName: string | symbol) => {
     let decoratorArgumentOptions: SerializePropertyArgumentObject;
 
     if (typeof decoratorArguments === "string") {
@@ -72,8 +72,13 @@ export function SerializeProperty(
         throw new Error(ERROR_MESSAGE_SYMBOL_PROPERTY_NAME);
       }
 
+      const transformKeyFunction =
+        Object.prototype.hasOwnProperty.call(target, "tsTransformKey")
+          ? target.tsTransformKey
+          : Object.getPrototypeOf(target).tsTransformKey;
+
       decoratorArgumentOptions = {
-        serializedKey: propertyName as string,
+        serializedKey: transformKeyFunction(String(propertyName)),
         ...decoratorArguments,
       };
     }
@@ -94,10 +99,10 @@ export function SerializeProperty(
 
       serializablePropertiesMap = SERIALIZABLE_CLASS_MAP.get(
         target,
-      ) as SerializePropertyOptionsMap;
+      );
     }
 
-    serializablePropertiesMap.set(
+    serializablePropertiesMap?.set(
       new SerializePropertyOptions(
         propertyName,
         decoratorArgumentOptions.serializedKey,

--- a/serialize_property.ts
+++ b/serialize_property.ts
@@ -78,7 +78,7 @@ export function SerializeProperty(
           : Object.getPrototypeOf(target).tsTransformKey;
 
       decoratorArgumentOptions = {
-        serializedKey: transformKeyFunction(String(propertyName)),
+        serializedKey: transformKeyFunction(propertyName),
         ...decoratorArguments,
       };
     }


### PR DESCRIPTION
## Fixes

closes #29 

## Description

Adds optional `tsTransformKey` functionality

## Proposed changes in this PR

- tsTransformKey to ... transform keys
- is inherited by children
- children can provide their own to override
- serialize property options override the transforms
- tests
- docs

ps. do we need a website now?

## Things to look at

- [x] Test coverage
- [x] Code Style
- [x] Documentation (READMEs etc)
