### PR TITLE
Fix empty class serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- fixed #83
 
 ### Added
 

--- a/serializable_test.ts
+++ b/serializable_test.ts
@@ -213,17 +213,3 @@ test({
     );
   },
 });
-
-test({
-  name: "should be able to serialize a serializable without any properties",
-  fn() {
-    class TestSerializable extends Serializable {}
-
-    assertEquals(new TestSerializable().toJson(), `{}`);
-    const serializedClass = new TestSerializable().fromJson({});
-    const propertyDescriptors = Object.getOwnPropertyDescriptors(
-      serializedClass,
-    );
-    assertEquals(Object.keys(serializedClass).length, 0);
-  },
-});

--- a/serializable_test.ts
+++ b/serializable_test.ts
@@ -213,3 +213,17 @@ test({
     );
   },
 });
+
+test({
+  name: "should be able to serialize a serializable without any properties",
+  fn() {
+    class TestSerializable extends Serializable {}
+
+    assertEquals(new TestSerializable().toJson(), `{}`);
+    const serializedClass = new TestSerializable().fromJson({});
+    const propertyDescriptors = Object.getOwnPropertyDescriptors(
+      serializedClass,
+    );
+    assertEquals(Object.keys(serializedClass).length, 0);
+  },
+});

--- a/serialize_property_test.ts
+++ b/serialize_property_test.ts
@@ -471,3 +471,73 @@ test({
     );
   },
 });
+
+test({
+  name: "should be able to serialize a serializable without any properties",
+  fn() {
+    class TestSerializable extends Serializable {}
+
+    assertEquals(new TestSerializable().toJson(), `{}`);
+    const serializedClass = new TestSerializable().fromJson({});
+    const propertyDescriptors = Object.getOwnPropertyDescriptors(
+      serializedClass,
+    );
+    assertEquals(Object.keys(serializedClass).length, 0);
+  },
+});
+
+test({
+  name:
+    "should be able to serialize child class and have it inherit it's parent's serialization logic correctly",
+  fn() {
+    class TestSerializable extends Serializable {
+      @SerializeProperty()
+      public test_property = 1;
+    }
+    class TestSerializableChild extends TestSerializable {}
+    // Parent
+    assertEquals(
+      new TestSerializable().toJson(),
+      `{"test_property":1}`,
+    );
+    assertEquals(
+      new TestSerializable().fromJson(`{"test_property":32}`)
+        .test_property,
+      32,
+    );
+    // Child
+    assertEquals(
+      new TestSerializableChild().toJson(),
+      `{"test_property":1}`,
+    );
+    assertEquals(
+      new TestSerializableChild().fromJson(`{"test_property":32}`)
+        .test_property,
+      32,
+    );
+  },
+});
+
+test({
+  name:
+    "should be able to serialize grandchild class and have it inherit it's grandparent's serialization logic correctly",
+  fn() {
+    class TestSerializable extends Serializable {
+      @SerializeProperty()
+      public test_property = 0;
+    }
+    class TestSerializableChild extends TestSerializable {}
+    class TestSerializableGrandChild extends TestSerializableChild {}
+
+    // Grandchild
+    assertEquals(
+      new TestSerializableGrandChild().toJson(),
+      `{"test_property":0}`,
+    );
+    assertEquals(
+      new TestSerializableGrandChild().fromJson(`{"test_property":33}`)
+        .test_property,
+      33,
+    );
+  },
+});


### PR DESCRIPTION
## Fixes

fixes #83 

## Description

Fixes issue where classes without any `@SerializeProperty()` decorator fails to be serialized

## Proposed changes in this PR

- Add logic to create serialization definitions on class construction if they weren't created when a `SerializeProperty` decorator was processed. This is recursive as parent constructors aren't called unless explicitly called via `super()`

## Things to look at

- [x] Test coverage
- [x] Code Style
- [x] Documentation (READMEs etc)
