### PR TITLE
update test scripts with coverage profiles

### DIFF
--- a/.github/workflows/ts_serialize_release.yml
+++ b/.github/workflows/ts_serialize_release.yml
@@ -32,10 +32,20 @@ jobs:
         run: deno cache test_deps.ts
 
       - name: Run Deno Tests with coverage
-        steps: deno test --coverage=coverage_profile --unstable
+        run: deno test --coverage=coverage --unstable
 
-      - name: Examine coverage
-        run: deno coverage --unstable coverage_profile
+      - name: lcov test coverage
+        run: deno coverage --unstable coverage --lcov > coverage.lcov
+        if: matrix.os == 'ubuntu-latest'
+
+      - name: Report code coverage
+        uses: zgosalvez/github-actions-report-lcov@v1
+        with:
+          coverage-files: coverage.lcov
+          minimum-coverage: 100
+          artifact-name: code-coverage-report
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        if: matrix.os == 'ubuntu-latest'
 
       - name: Run package.json Generation Tests
         run: .github/workflows/scripts/npm_release_files/create_npm_package_file_test.sh

--- a/.github/workflows/ts_serialize_release.yml
+++ b/.github/workflows/ts_serialize_release.yml
@@ -31,8 +31,11 @@ jobs:
       - name: Cache Dependencies
         run: deno cache test_deps.ts
 
-      - name: Run Deno Tests
-        run: deno test
+      - name: Run Deno Tests with coverage
+        run: deno test --coverage=coverage_profile --unstable
+
+      - name: Examine coverage
+        run: deno coverage --unstable coverage_profile
 
       - name: Run package.json Generation Tests
         run: .github/workflows/scripts/npm_release_files/create_npm_package_file_test.sh

--- a/.github/workflows/ts_serialize_release.yml
+++ b/.github/workflows/ts_serialize_release.yml
@@ -32,7 +32,7 @@ jobs:
         run: deno cache test_deps.ts
 
       - name: Run Deno Tests with coverage
-        run: deno test --coverage=coverage_profile --unstable
+        steps: deno test --coverage=coverage_profile --unstable
 
       - name: Examine coverage
         run: deno coverage --unstable coverage_profile

--- a/.github/workflows/ts_serialize_tests.yml
+++ b/.github/workflows/ts_serialize_tests.yml
@@ -42,11 +42,11 @@ jobs:
       - name: Examine test coverage
         run: deno coverage --unstable test_coverage_profile
 
-      - name: locv test coverage
+      - name: lcov test coverage
         run: deno coverage --unstable test_coverage_profile --lcov > test_coverage_profile.lcov
         if: matrix.os == 'ubuntu-latest'
 
-      - name: generate test coverage html from locv
+      - name: generate test coverage html from lcov
         run: genhtml -o test_coverage_profile/html test_coverage_profile.lcov
         if: matrix.os == 'ubuntu-latest'
 

--- a/.github/workflows/ts_serialize_tests.yml
+++ b/.github/workflows/ts_serialize_tests.yml
@@ -47,8 +47,9 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
 
       - name: install lcov and generate test coverage html
-        run: apt-get update && apt-get install lcov
-        run: genhtml -o test_coverage_profile/html test_coverage_profile.lcov
+        steps:
+         - run: apt-get update && apt-get install lcov
+         - run: genhtml -o test_coverage_profile/html test_coverage_profile.lcov
         if: matrix.os == 'ubuntu-latest'
 
       - name: Run package.json Generation Tests

--- a/.github/workflows/ts_serialize_tests.yml
+++ b/.github/workflows/ts_serialize_tests.yml
@@ -46,7 +46,8 @@ jobs:
         run: deno coverage --unstable test_coverage_profile --lcov > test_coverage_profile.lcov
         if: matrix.os == 'ubuntu-latest'
 
-      - name: generate test coverage html from lcov
+      - name: install lcov and generate test coverage html
+        run: apt-get update && apt-get install lcov
         run: genhtml -o test_coverage_profile/html test_coverage_profile.lcov
         if: matrix.os == 'ubuntu-latest'
 

--- a/.github/workflows/ts_serialize_tests.yml
+++ b/.github/workflows/ts_serialize_tests.yml
@@ -44,9 +44,11 @@ jobs:
 
       - name: locv test coverage
         run: deno coverage --unstable test_coverage_profile --lcov > test_coverage_profile.lcov
+        if: matrix.os == 'ubuntu-latest'
 
       - name: generate test coverage html from locv
         run: genhtml -o test_coverage_profile/html test_coverage_profile.lcov
+        if: matrix.os == 'ubuntu-latest'
 
       - name: Run package.json Generation Tests
         run: .github/workflows/scripts/npm_release_files/create_npm_package_file_test.sh

--- a/.github/workflows/ts_serialize_tests.yml
+++ b/.github/workflows/ts_serialize_tests.yml
@@ -43,10 +43,10 @@ jobs:
         run: deno coverage --unstable test_coverage_profile
 
       - name: locv test coverage
-        run: deno coverage --unstable test_coverage_profile --lcov > test_coverage_profile/locv/test_coverage_profile.lcov
+        run: deno coverage --unstable test_coverage_profile --lcov > test_coverage_profile.lcov
 
       - name: generate test coverage html from locv
-        run: genhtml -o test_coverage_profile/html test_coverage_profile/locv/test_coverage_profile.lcov
+        run: genhtml -o test_coverage_profile/html test_coverage_profile.lcov
 
       - name: Run package.json Generation Tests
         run: .github/workflows/scripts/npm_release_files/create_npm_package_file_test.sh

--- a/.github/workflows/ts_serialize_tests.yml
+++ b/.github/workflows/ts_serialize_tests.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Report code coverage
         uses: zgosalvez/github-actions-report-lcov@v1
         with:
-          coverage-files: coverage/*.json
+          coverage-files: coverage.lcov
           minimum-coverage: 100
           artifact-name: code-coverage-report
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ts_serialize_tests.yml
+++ b/.github/workflows/ts_serialize_tests.yml
@@ -37,20 +37,22 @@ jobs:
         run: deno cache test_deps.ts
 
       - name: Run Deno Tests with coverage
-        run: deno test --coverage=test_coverage_profile --unstable
+        run: deno test --coverage=coverage --unstable
 
       - name: Examine test coverage
-        run: deno coverage --unstable test_coverage_profile
+        run: deno coverage --unstable coverage
 
       - name: lcov test coverage
-        run: deno coverage --unstable test_coverage_profile --lcov > test_coverage_profile.lcov
+        run: deno coverage --unstable coverage --lcov > coverage.lcov
         if: matrix.os == 'ubuntu-latest'
 
-      - name: test coverage test
-        uses: romeovs/lcov-reporter-action@v0.2.16
+      - name: Report code coverage
+        uses: zgosalvez/github-actions-report-lcov@v1
         with:
+          coverage-files: coverage/*.json
+          minimum-coverage: 100
+          artifact-name: code-coverage-report
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          lcov-file: ./test_coverage_profile.lcov
         if: matrix.os == 'ubuntu-latest'
 
       - name: Run package.json Generation Tests

--- a/.github/workflows/ts_serialize_tests.yml
+++ b/.github/workflows/ts_serialize_tests.yml
@@ -47,9 +47,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
 
       - name: install lcov and generate test coverage html
-        steps:
-          run: apt-get update && apt-get install lcov
-          run: genhtml -o test_coverage_profile/html test_coverage_profile.lcov
+        run: apt-get update && apt-get install lcov && genhtml -o test_coverage_profile/html test_coverage_profile.lcov
         if: matrix.os == 'ubuntu-latest'
 
       - name: Run package.json Generation Tests

--- a/.github/workflows/ts_serialize_tests.yml
+++ b/.github/workflows/ts_serialize_tests.yml
@@ -48,8 +48,8 @@ jobs:
 
       - name: install lcov and generate test coverage html
         steps:
-          - run: apt-get update && apt-get install lcov
-          - run: genhtml -o test_coverage_profile/html test_coverage_profile.lcov
+          run: apt-get update && apt-get install lcov
+          run: genhtml -o test_coverage_profile/html test_coverage_profile.lcov
         if: matrix.os == 'ubuntu-latest'
 
       - name: Run package.json Generation Tests

--- a/.github/workflows/ts_serialize_tests.yml
+++ b/.github/workflows/ts_serialize_tests.yml
@@ -39,9 +39,6 @@ jobs:
       - name: Run Deno Tests with coverage
         run: deno test --coverage=coverage --unstable
 
-      - name: Examine test coverage
-        run: deno coverage --unstable coverage
-
       - name: lcov test coverage
         run: deno coverage --unstable coverage --lcov > coverage.lcov
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ts_serialize_tests.yml
+++ b/.github/workflows/ts_serialize_tests.yml
@@ -37,10 +37,16 @@ jobs:
         run: deno cache test_deps.ts
 
       - name: Run Deno Tests with coverage
-        run: deno test --coverage=coverage_profile --unstable
+        run: deno test --coverage=test_coverage_profile --unstable
 
-      - name: Examine coverage
-        run: deno coverage --unstable coverage_profile
+      - name: Examine test coverage
+        run: deno coverage --unstable test_coverage_profile
+
+      - name: locv test coverage
+        run: deno coverage --unstable test_coverage_profile --lcov > test_coverage_profile/locv/test_coverage_profile.lcov
+
+      - name: generate test coverage html from locv
+        run: genhtml -o test_coverage_profile/html test_coverage_profile/locv/test_coverage_profile.lcov
 
       - name: Run package.json Generation Tests
         run: .github/workflows/scripts/npm_release_files/create_npm_package_file_test.sh

--- a/.github/workflows/ts_serialize_tests.yml
+++ b/.github/workflows/ts_serialize_tests.yml
@@ -36,8 +36,11 @@ jobs:
       - name: Cache Dependencies
         run: deno cache test_deps.ts
 
-      - name: Run Deno Tests
-        run: deno test
+      - name: Run Deno Tests with coverage
+        run: deno test --coverage=coverage_profile --unstable
+
+      - name: Examine coverage
+        run: deno coverage --unstable coverage_profile
 
       - name: Run package.json Generation Tests
         run: .github/workflows/scripts/npm_release_files/create_npm_package_file_test.sh

--- a/.github/workflows/ts_serialize_tests.yml
+++ b/.github/workflows/ts_serialize_tests.yml
@@ -48,8 +48,8 @@ jobs:
 
       - name: install lcov and generate test coverage html
         steps:
-         - run: apt-get update && apt-get install lcov
-         - run: genhtml -o test_coverage_profile/html test_coverage_profile.lcov
+          - run: apt-get update && apt-get install lcov
+          - run: genhtml -o test_coverage_profile/html test_coverage_profile.lcov
         if: matrix.os == 'ubuntu-latest'
 
       - name: Run package.json Generation Tests

--- a/.github/workflows/ts_serialize_tests.yml
+++ b/.github/workflows/ts_serialize_tests.yml
@@ -50,7 +50,7 @@ jobs:
         uses: romeovs/lcov-reporter-action@v0.2.16
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          lcov-file: test_coverage_profile.lcov
+          lcov-file: ./test_coverage_profile.lcov
         if: matrix.os == 'ubuntu-latest'
 
       - name: Run package.json Generation Tests

--- a/.github/workflows/ts_serialize_tests.yml
+++ b/.github/workflows/ts_serialize_tests.yml
@@ -47,7 +47,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
 
       - name: test coverage test
-        uses: vebr/jest-lcov-reporter@v0.2.0
+        uses: romeovs/lcov-reporter-action@v0.2.16
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           lcov-file: test_coverage_profile.lcov

--- a/.github/workflows/ts_serialize_tests.yml
+++ b/.github/workflows/ts_serialize_tests.yml
@@ -46,8 +46,11 @@ jobs:
         run: deno coverage --unstable test_coverage_profile --lcov > test_coverage_profile.lcov
         if: matrix.os == 'ubuntu-latest'
 
-      - name: install lcov and generate test coverage html
-        run: apt-get update && apt-get install lcov && genhtml -o test_coverage_profile/html test_coverage_profile.lcov
+      - name: test coverage test
+        uses: vebr/jest-lcov-reporter@v0.2.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          lcov-file: test_coverage_profile.lcov
         if: matrix.os == 'ubuntu-latest'
 
       - name: Run package.json Generation Tests

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ examples/node/*
 !examples/node/tsconfig.json
 !examples/node/package.json
 !examples/node/README.md
+coverage_profile
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@ examples/node/*
 !examples/node/tsconfig.json
 !examples/node/package.json
 !examples/node/README.md
-test_coverage_profile
-test_coverage_profile.lcov
+coverage
+coverage.lcov
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ examples/node/*
 !examples/node/tsconfig.json
 !examples/node/package.json
 !examples/node/README.md
-coverage_profile
+test_coverage_profile
+test_coverage_profile.lcov
 .DS_Store

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,1 +1,1 @@
-{ "deno.enable": true } 
+{ "deno.enable": true }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to
 ## [unreleased]
 
 ## Added
+
 - ci with test coverage
 - ci fails to build if we do not have 100% test coverage
 - GitHub actions reports on the PR with coverage reports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+## Added
+- ci with test coverage
+- ci fails to build if we do not have 100% test coverage
+- GitHub actions reports on the PR with coverage reports
+
 ## [v1.3.0] - 2021-02-25
 
 ### Changed

--- a/docs/blog.md
+++ b/docs/blog.md
@@ -21,9 +21,9 @@ First, a JSON User document:
 
 ```json
 {
-    "first_name":  "Theodore",
-    "last_name": "Esquire",
-    "created_date": "2020-09-24T00:00:00.000Z"
+  "first_name": "Theodore",
+  "last_name": "Esquire",
+  "created_date": "2020-09-24T00:00:00.000Z"
 }
 ```
 

--- a/examples/deno/tsconfig.json
+++ b/examples/deno/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "compilerOptions": {
-        "experimentalDecorators": true,
-    }
+  "compilerOptions": {
+    "experimentalDecorators": true
+  }
 }

--- a/examples/fixtures/from.json
+++ b/examples/fixtures/from.json
@@ -1,13 +1,13 @@
 {
-    "serializedPropertyNoArg": "fromJSON",
-    "rename_test": "fromJSON",
-    "rename_test_by_property": "fromJSON",
-    "fromJSONStrategyTest": "fromJSON",
-    "toJSONStrategyTest": "fromJSON",
-    "composeStrategyTest": "fromJSON",
-    "asTest":{
-        "sub_property": "fromJSON"
-    },
-    "isoDate": "2020-06-04T19:01:47.831Z",
-    "createDate": "2099-11-25"
+  "serializedPropertyNoArg": "fromJSON",
+  "rename_test": "fromJSON",
+  "rename_test_by_property": "fromJSON",
+  "fromJSONStrategyTest": "fromJSON",
+  "toJSONStrategyTest": "fromJSON",
+  "composeStrategyTest": "fromJSON",
+  "asTest": {
+    "sub_property": "fromJSON"
+  },
+  "isoDate": "2020-06-04T19:01:47.831Z",
+  "createDate": "2099-11-25"
 }

--- a/examples/fixtures/to.json
+++ b/examples/fixtures/to.json
@@ -1,13 +1,13 @@
 {
-    "serializedPropertyNoArg": "toJSON",
-    "rename_test": "toJSON",
-    "rename_test_by_property": "toJSON",
-    "fromJSONStrategyTest": "toJSON",
-    "toJSONStrategyTest": "toJSON strategy changed",
-    "composeStrategyTest": "toJSON strategy changed",
-    "asTest":{
-        "sub_property": "toJSON"
-    },
-    "isoDate": "2020-06-04T19:01:47.831Z",
-    "createDate": "2099-11-25T00:00:00.000Z"
+  "serializedPropertyNoArg": "toJSON",
+  "rename_test": "toJSON",
+  "rename_test_by_property": "toJSON",
+  "fromJSONStrategyTest": "toJSON",
+  "toJSONStrategyTest": "toJSON strategy changed",
+  "composeStrategyTest": "toJSON strategy changed",
+  "asTest": {
+    "sub_property": "toJSON"
+  },
+  "isoDate": "2020-06-04T19:01:47.831Z",
+  "createDate": "2099-11-25T00:00:00.000Z"
 }

--- a/examples/node/tsconfig.json
+++ b/examples/node/tsconfig.json
@@ -1,7 +1,7 @@
 {
-    "compilerOptions": {
-        "experimentalDecorators": true,
-        "resolveJsonModule": true,
-        "esModuleInterop": true,
-    }
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true
+  }
 }

--- a/polymorphic_test.ts
+++ b/polymorphic_test.ts
@@ -481,52 +481,6 @@ test({
     assert(polyClass instanceof TestClass2020);
     assertEquals((polyClass as TestClass2020).someDate?.getFullYear(), 2020);
 
-    const testData2 = { "someDate": "2010-06-01" };
-    const polyClass2 = polymorphicClassFromJSON(AbstractClass, testData2);
-
-    assert(polyClass2 instanceof TestClassOtherYear);
-    assertNotEquals(
-      (polyClass2 as TestClassOtherYear).someDate?.getFullYear(),
-      2020,
-    );
-  },
-});
-
-test({
-  name: "polymorphic switch complex custom test - as string",
-  fn() {
-    abstract class AbstractClass extends Serializable {}
-
-    class TestClass2020 extends AbstractClass {
-      @SerializeProperty({
-        fromJSONStrategy: (value) => new Date(value as string),
-      })
-      // Only deserialize if this value matches the year 2020
-      @PolymorphicSwitch(
-        () => new TestClass2020(),
-        (propertyValue) => (propertyValue as Date).getFullYear() === 2020,
-      )
-      public someDate?: Date;
-    }
-
-    class TestClassOtherYear extends AbstractClass {
-      @SerializeProperty({
-        fromJSONStrategy: (value) => new Date(value as string),
-      })
-      // Only deserialize if this value doesn't match the year 2020
-      @PolymorphicSwitch(
-        () => new TestClassOtherYear(),
-        (propertyValue) => (propertyValue as Date).getFullYear() !== 2020,
-      )
-      public someDate?: Date;
-    }
-
-    const testData = { "someDate": "2020-06-01" };
-    const polyClass = polymorphicClassFromJSON(AbstractClass, testData);
-
-    assert(polyClass instanceof TestClass2020);
-    assertEquals((polyClass as TestClass2020).someDate?.getFullYear(), 2020);
-
     const testData2 = `{ "someDate": "2010-06-01" }`;
     const polyClass2 = polymorphicClassFromJSON(AbstractClass, testData2);
 

--- a/polymorphic_test.ts
+++ b/polymorphic_test.ts
@@ -491,3 +491,49 @@ test({
     );
   },
 });
+
+test({
+  name: "polymorphic switch complex custom test - as string",
+  fn() {
+    abstract class AbstractClass extends Serializable {}
+
+    class TestClass2020 extends AbstractClass {
+      @SerializeProperty({
+        fromJSONStrategy: (value) => new Date(value as string),
+      })
+      // Only deserialize if this value matches the year 2020
+      @PolymorphicSwitch(
+        () => new TestClass2020(),
+        (propertyValue) => (propertyValue as Date).getFullYear() === 2020,
+      )
+      public someDate?: Date;
+    }
+
+    class TestClassOtherYear extends AbstractClass {
+      @SerializeProperty({
+        fromJSONStrategy: (value) => new Date(value as string),
+      })
+      // Only deserialize if this value doesn't match the year 2020
+      @PolymorphicSwitch(
+        () => new TestClassOtherYear(),
+        (propertyValue) => (propertyValue as Date).getFullYear() !== 2020,
+      )
+      public someDate?: Date;
+    }
+
+    const testData = { "someDate": "2020-06-01" };
+    const polyClass = polymorphicClassFromJSON(AbstractClass, testData);
+
+    assert(polyClass instanceof TestClass2020);
+    assertEquals((polyClass as TestClass2020).someDate?.getFullYear(), 2020);
+
+    const testData2 = `{ "someDate": "2010-06-01" }`;
+    const polyClass2 = polymorphicClassFromJSON(AbstractClass, testData2);
+
+    assert(polyClass2 instanceof TestClassOtherYear);
+    assertNotEquals(
+      (polyClass2 as TestClassOtherYear).someDate?.getFullYear(),
+      2020,
+    );
+  },
+});


### PR DESCRIPTION
**Description**

with deno@v1.8.1 better test coverage tools are available to create lcov files

**Proposed changes in this PR**

- ci with test coverage
- ci fails to build if we do not have 100% test coverage
- GitHub actions reports on the PR with coverage reports
- adds downloadable html artifact 
<img width="435" alt="Screen Shot 2021-03-12 at 8 28 01 PM" src="https://user-images.githubusercontent.com/27963753/111014428-8e7c8380-8371-11eb-9a5c-9a6480d83a92.png">

[code-coverage-report.zip](https://github.com/GameBridgeAI/ts_serialize/files/6133915/code-coverage-report.zip)



**Things to look at**

- [x] Test coverage
- [x] Code Style
- [x] Documentation (`README.md`, `doc/`, `examples/`, etc..)
