### PR TITLE
ISSUE-125 Handle arrays with to/fromJSONStrategy properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ examples/node/*
 coverage
 coverage.lcov
 .DS_Store
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,1 +1,6 @@
-{ "deno.enable": true }
+{
+    "deno.enable": true,
+    "deno.lint": true,
+    "deno.unstable": false,
+    "deno.path": "/Users/saim.khan/.deno/bin/deno"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "deno.enable": true,
-    "deno.lint": true,
-    "deno.unstable": false,
-    "deno.path": "/Users/saim.khan/.deno/bin/deno"
-}

--- a/serializable.ts
+++ b/serializable.ts
@@ -157,6 +157,8 @@ export function toPojo(
         if (item instanceof Serializable) {
           return toPojo(item);
         }
+
+        // if item is not Serializable we will apply the toJSONStrategy on the whole array so return items as is
         notSerializableElements = true;
         return item;
       });
@@ -195,16 +197,16 @@ function fromJSON<T>(
       continue;
     }
 
+    // if strategy is not provided we apply the default on the value/elements of the array
     if (!fromJSONStrategy) {
       const defaultFromJSONStrategy = fromJSONDefault;
       accumulator[propertyKey as keyof T] = Array.isArray(value)
       ? value.map((v) => defaultFromJSONStrategy(v)) : defaultFromJSONStrategy(value as JSONValue)
       continue;
     }
+
+    // if a strategy is provided we apply the strategy on the entire array
     accumulator[propertyKey as keyof T] = fromJSONStrategy(value as JSONValue);
-    // accumulator[propertyKey as keyof T] = Array.isArray(value)
-    //   ? value.map((v) => fromJSONStrategy(v))
-    //   : fromJSONStrategy(value as JSONValue);
   }
 
   return Object.assign(

--- a/serialize_property_test.ts
+++ b/serialize_property_test.ts
@@ -7,7 +7,7 @@ import {
   fail,
   test,
 } from "./test_deps.ts";
-import { Serializable } from "./serializable.ts";
+import { JSONArray, Serializable } from "./serializable.ts";
 import { SerializeProperty } from "./serialize_property.ts";
 import {
   ERROR_DUPLICATE_SERIALIZE_KEY,
@@ -216,7 +216,7 @@ test({
     }
     class Test extends Serializable {
       @SerializeProperty({
-        fromJSONStrategy: (v) => new OtherClass().fromJSON(v),
+        fromJSONStrategy: (v) => (v as JSONArray).map(el => new OtherClass().fromJSON(el)),
       })
       array!: OtherClass[];
     }
@@ -558,5 +558,16 @@ test({
       public test_property = 0;
     }
     assertEquals(new Test().toJSON(), `{"test_property":0}`);
+  },
+});
+
+test({
+  name: "custom toJSONStrategy with array",
+  fn() {
+    class Test extends Serializable {
+      @SerializeProperty({ toJSONStrategy: (v) => v.join(".") })
+      public test_property = [0,1];
+    }
+    assertEquals(new Test().toJSON(), `{"test_property":"0.1"}`);
   },
 });

--- a/serialize_property_test.ts
+++ b/serialize_property_test.ts
@@ -562,7 +562,7 @@ test({
 });
 
 test({
-  name: "custom toJSONStrategy with array",
+  name: "custom toJSONStrategy with an array of data",
   fn() {
     class Test extends Serializable {
       @SerializeProperty({ toJSONStrategy: (v) => v.join(".") })

--- a/strategy/from_json/to_serializable_test.ts
+++ b/strategy/from_json/to_serializable_test.ts
@@ -2,7 +2,7 @@
 
 import { assert, assertEquals, test } from "../../test_deps.ts";
 import { toSerializable } from "./to_serializable.ts";
-import { Serializable } from "../../serializable.ts";
+import { JSONArray, Serializable } from "../../serializable.ts";
 import { SerializeProperty } from "../../serialize_property.ts";
 
 test({
@@ -104,7 +104,7 @@ test({
     }
     class Test extends Serializable {
       @SerializeProperty({
-        fromJSONStrategy: (v) => new OtherClass().fromJSON(v),
+        fromJSONStrategy: (v) => (v as JSONArray).map(el => new OtherClass().fromJSON(el)),
       })
       array!: OtherClass[];
     }


### PR DESCRIPTION


**Description**

Issue fixed: [125](https://github.com/GameBridgeAI/ts_serialize/issues/125)

Here we change the to/fromJSONStrategy handling when the property is an array. If a strategy is provided, it is applied on the full array rather than individually on the elements of the array. 

**Things to look at**

- [ ] Test coverage
- [ ] Code Style
- [ ] Documentation (`README.md`, `doc/`, `examples/`, etc..)
