### PR TITLE
[iss-127] remove array as an option from strategies

### DIFF
--- a/.github/workflows/scripts/npm_release_files/ts_serialize.d.ts
+++ b/.github/workflows/scripts/npm_release_files/ts_serialize.d.ts
@@ -2,9 +2,6 @@ declare module "@gamebridgeai/ts_serialize" {
   /** A JSON object where each property value is a simple JSON value. */
   export type JSONObject = { [key: string]: JSONValue };
 
-  /** A JSON array where each value is a simple JSON value. */
-  export interface JSONArray extends Array<JSONValue> {}
-
   /** A property value in a JSON object. */
   export type JSONValue =
     | string
@@ -12,7 +9,7 @@ declare module "@gamebridgeai/ts_serialize" {
     | boolean
     | null
     | JSONObject
-    | JSONArray;
+    | JSONValue[];
 
   /** to be implemented by external authors on their models  */
   export interface TransformKey {

--- a/.github/workflows/scripts/npm_release_files/ts_serialize.d.ts
+++ b/.github/workflows/scripts/npm_release_files/ts_serialize.d.ts
@@ -64,24 +64,17 @@ declare module "@gamebridgeai/ts_serialize" {
 
   /** Functions used when hydrating data */
   export type FromJSONStrategy = (value: JSONValue) => any;
-  export type FromJSONStrategyArgument =
-    (FromJSONStrategy | FromJSONStrategy[])[];
 
   /** Functions used when dehydrating data */
   export type ToJSONStrategy = (value: any) => JSONValue;
-  export type ToJSONStrategyArgument = (ToJSONStrategy | ToJSONStrategy[])[];
 
   /** string/symbol property name or options for (de)serializing values */
   export type SerializePropertyArgument =
     | string
     | {
       serializedKey?: string;
-      fromJSONStrategy?:
-        | FromJSONStrategy
-        | FromJSONStrategyArgument;
-      toJSONStrategy?:
-        | ToJSONStrategy
-        | ToJSONStrategyArgument;
+      fromJSONStrategy?: FromJSONStrategy;
+      toJSONStrategy?: ToJSONStrategy;
     };
 
   /** Property wrapper that adds serializable options to the class map
@@ -96,9 +89,10 @@ declare module "@gamebridgeai/ts_serialize" {
    * Converts value from functions provided as parameters
    */
   export function composeStrategy(
-    ...fns:
-      | FromJSONStrategyArgument
-      | ToJSONStrategyArgument
+    ...fns: (
+      | FromJSONStrategy
+      | ToJSONStrategy
+    )[]
   ): FromJSONStrategy | ToJSONStrategy;
 
   /** revive data using `fromJSON` on a subclass type */
@@ -144,7 +138,7 @@ declare module "@gamebridgeai/ts_serialize" {
 
   /**
    * \@PolymorphicSwitch property decorator.
-   * 
+   *
    * Maps the provided initializer function and value or propertyValueTest to the parent class
    */
   export function PolymorphicSwitch(

--- a/.github/workflows/ts_serialize_tests.yml
+++ b/.github/workflows/ts_serialize_tests.yml
@@ -36,12 +36,14 @@ jobs:
       - name: Cache Dependencies
         run: deno cache test_deps.ts
 
-      - name: Run Deno Tests with coverage
-        run: deno test --coverage=coverage --unstable
+      - name: deno test # with coverage
+        # run: deno test --coverage=coverage --unstable
+        run: deno test
 
       - name: lcov test coverage
         run: deno coverage --unstable coverage --lcov > coverage.lcov
-        if: matrix.os == 'ubuntu-latest'
+        # if: matrix.os == 'ubuntu-latest'
+        if: false
 
       - name: Report code coverage
         uses: zgosalvez/github-actions-report-lcov@v1
@@ -50,7 +52,8 @@ jobs:
           minimum-coverage: 100
           artifact-name: code-coverage-report
           github-token: ${{ secrets.GITHUB_TOKEN }}
-        if: matrix.os == 'ubuntu-latest'
+        # if: matrix.os == 'ubuntu-latest'
+        if: false
 
       - name: Run package.json Generation Tests
         run: .github/workflows/scripts/npm_release_files/create_npm_package_file_test.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+- removes array as an strategy, use `composeStrategy` instead
+- fmt with deno@1.10.3
+
+
 ## [v1.3.1] - 2021-03-14
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 - removes array as an strategy, use `composeStrategy` instead
 - fmt with deno@1.10.3
 - turn off unstable code coverage
+- remove JSONArray for JSONValue[]
 
 ## [v1.3.1] - 2021-03-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to
 
 - removes array as an strategy, use `composeStrategy` instead
 - fmt with deno@1.10.3
-
+- turn off unstable code coverage
 
 ## [v1.3.1] - 2021-03-14
 

--- a/polymorphic.ts
+++ b/polymorphic.ts
@@ -14,18 +14,18 @@ import { fromJSONDefault } from "./strategy/from_json/default.ts";
 export type InitializerFunction = () => Serializable;
 
 /** Polymorphic class deserializer
- * 
+ *
  * There are currently 2 ways of doing polymorphic deserialization:
  * 1. Manually using \@PolymorphicResolver on a static method on the parent class
- * 
+ *
  * This works by keeping a map of target 'parent' classes to resolver functions.
  * These are set when a static method is annotated with @PolymorphicResolver.
- * You can then call `serializePolymorphicClass` with the parent class and an 
+ * You can then call `serializePolymorphicClass` with the parent class and an
  * input the input is passed to whatever the corresponding resolver function,
  * which will make a determination and returns an instance of a 'child' class
- * 
+ *
  * 2. Implicitly using \@PolymorphicSwitch instance property on a child class.
- * 
+ *
  * This works by mapping the decorated class' parent prototype to the child
  * class, property key, property value (or property value test), and initializer
  * function
@@ -61,7 +61,7 @@ function registerPolymorphicResolver(
 
 /**
  * \@PolymorphicSwitch property decorator.
- * 
+ *
  * Maps the provided initializer function and value or propertyValueTest to the parent class
  */
 export function PolymorphicSwitch(

--- a/serializable.ts
+++ b/serializable.ts
@@ -11,9 +11,6 @@ export type JSONObject = {
   [key: string]: JSONValue;
 };
 
-/** A `JSONArray` where each value is a `JSONValue`. */
-export interface JSONArray extends Array<JSONValue> {}
-
 /** A JSONValue */
 export type JSONValue =
   | string
@@ -21,7 +18,7 @@ export type JSONValue =
   | boolean
   | null
   | JSONObject
-  | JSONArray;
+  | JSONValue[];
 
 /** called against every property key transforming the key with the provided function */
 export declare interface TransformKey {

--- a/serializable.ts
+++ b/serializable.ts
@@ -79,7 +79,7 @@ function getOrInitializeDefaultSerializerLogicForParents(
 /** Serializable
  *  provides a constructed class for serializing data
  *  to be used with the decorator `SerializeProperty`
- * 
+ *
  *       class Example extends Serializable {
  *         @SerializeProperty()
  *         public testName = "toJSON";

--- a/serialize_property.ts
+++ b/serialize_property.ts
@@ -4,11 +4,8 @@ import { SERIALIZABLE_CLASS_MAP } from "./serializable.ts";
 
 import { SerializePropertyOptionsMap } from "./serialize_property_options_map.ts";
 import {
-  composeStrategy,
   FromJSONStrategy,
-  FromJSONStrategyArgument,
   ToJSONStrategy,
-  ToJSONStrategyArgument,
 } from "./strategy/compose_strategy.ts";
 import { ERROR_SYMBOL_PROPERTY_NAME } from "./error_messages.ts";
 
@@ -20,18 +17,14 @@ export class SerializePropertyOptions {
   constructor(
     public propertyKey: string | symbol,
     public serializedKey: string,
-    fromJSONStrategy?: FromJSONStrategy | FromJSONStrategyArgument,
-    toJSONStrategy?: ToJSONStrategy | ToJSONStrategyArgument,
+    fromJSONStrategy?: FromJSONStrategy,
+    toJSONStrategy?: ToJSONStrategy,
   ) {
-    if (Array.isArray(fromJSONStrategy)) {
-      this.fromJSONStrategy = composeStrategy(...fromJSONStrategy);
-    } else if (fromJSONStrategy) {
+    if (fromJSONStrategy) {
       this.fromJSONStrategy = fromJSONStrategy;
     }
 
-    if (Array.isArray(toJSONStrategy)) {
-      this.toJSONStrategy = composeStrategy(...toJSONStrategy);
-    } else if (toJSONStrategy) {
+    if (toJSONStrategy) {
       this.toJSONStrategy = toJSONStrategy;
     }
   }
@@ -46,42 +39,34 @@ export type SerializePropertyArgument =
   | ToSerializedKeyStrategy
   | {
     serializedKey?: string | ToSerializedKeyStrategy;
-    fromJSONStrategy?:
-      | FromJSONStrategy
-      | FromJSONStrategyArgument;
-    toJSONStrategy?:
-      | ToJSONStrategy
-      | ToJSONStrategyArgument;
+    fromJSONStrategy?: FromJSONStrategy;
+    toJSONStrategy?: ToJSONStrategy;
   };
 
 /** converted interface for `SerializePropertyArgument` */
 interface SerializePropertyArgumentObject {
   serializedKey: string;
-  fromJSONStrategy?:
-    | FromJSONStrategy
-    | FromJSONStrategyArgument;
-  toJSONStrategy?:
-    | ToJSONStrategy
-    | ToJSONStrategyArgument;
+  fromJSONStrategy?: FromJSONStrategy;
+  toJSONStrategy?: ToJSONStrategy;
 }
 
 /** Property wrapper that adds `SerializeProperty` options to the class map
- * 
+ *
  *       class ExampleOne extends Serializable {
  *         @SerializeProperty()
  *         public testName = "toJSON";
  *       }
- * 
+ *
  *       class ExampleTwo extends Serializable {
  *         @SerializeProperty("test_name")
  *         public testName = "toJSON";
  *       }
- * 
+ *
  *       class ExampleTwo extends Serializable {
  *         @SerializeProperty((key) => string)
  *         public testName = "toJSON";
  *       }
- * 
+ *
  *       class ExampleThree extends Serializable {
  *         @SerializeProperty({
  *           serializeKey: "test_name",
@@ -89,7 +74,7 @@ interface SerializePropertyArgumentObject {
  *           toJSONStrategy: (any) => jsonValue
  *         })
  *         public testName = "toJSON";
- *       }  
+ *       }
  */
 export function SerializeProperty(
   args?: string | SerializePropertyArgument,
@@ -135,7 +120,7 @@ export function SerializeProperty(
   };
 }
 
-/** Parses the arguments provided to SerializeProperty and 
+/** Parses the arguments provided to SerializeProperty and
  * returns an object used to create a key mapping
  */
 function getDecoratorArgumentOptions(

--- a/serialize_property_test.ts
+++ b/serialize_property_test.ts
@@ -538,25 +538,3 @@ test({
     );
   },
 });
-
-test({
-  name: "fromJSONStrategy with array",
-  fn() {
-    class Test extends Serializable {
-      @SerializeProperty({ fromJSONStrategy: [(v) => v] })
-      public test_property = 0;
-    }
-    assertEquals(new Test().fromJSON({ test_property: 99 }).test_property, 99);
-  },
-});
-
-test({
-  name: "toJSONStrategy with array",
-  fn() {
-    class Test extends Serializable {
-      @SerializeProperty({ toJSONStrategy: [(v) => v] })
-      public test_property = 0;
-    }
-    assertEquals(new Test().toJSON(), `{"test_property":0}`);
-  },
-});

--- a/strategy/compose_strategy.ts
+++ b/strategy/compose_strategy.ts
@@ -3,22 +3,20 @@ import { JSONValue } from "../serializable.ts";
 
 /** Functions used when hydrating data */
 export type FromJSONStrategy = (value: JSONValue) => any;
-export type FromJSONStrategyArgument =
-  (FromJSONStrategy | FromJSONStrategy[])[];
 
 /** Functions used when dehydrating data */
 export type ToJSONStrategy = (value: any) => JSONValue;
-export type ToJSONStrategyArgument = (ToJSONStrategy | ToJSONStrategy[])[];
 /** Function to build a `fromJSONStrategy` or `toJSONStrategy`.
  * Converts value from functions provided as parameters
  */
 export function composeStrategy(
-  ...fns:
-    | FromJSONStrategyArgument
-    | ToJSONStrategyArgument
+  ...fns: (
+    | FromJSONStrategy
+    | ToJSONStrategy
+  )[]
 ): FromJSONStrategy | ToJSONStrategy {
   return function _composeStrategy(val: any): any {
-    return fns.flat().reduce(
+    return fns.reduce(
       (acc: any, fn: FromJSONStrategy | ToJSONStrategy) => fn(acc),
       val,
     );

--- a/strategy/compose_strategy.ts
+++ b/strategy/compose_strategy.ts
@@ -6,6 +6,7 @@ export type FromJSONStrategy = (value: JSONValue) => any;
 
 /** Functions used when dehydrating data */
 export type ToJSONStrategy = (value: any) => JSONValue;
+
 /** Function to build a `fromJSONStrategy` or `toJSONStrategy`.
  * Converts value from functions provided as parameters
  */

--- a/strategy/from_json/to_object_containing.ts
+++ b/strategy/from_json/to_object_containing.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2021 Gamebridge.ai authors. All rights reserved. MIT license.
 
-import { JSONArray, JSONValue, Serializable } from "../../serializable.ts";
+import { JSONValue, Serializable } from "../../serializable.ts";
 import { FromJSONStrategy } from "../compose_strategy.ts";
 import {
   ERROR_TO_OBJECT_CONTAINING_INVALID_SUB_VALUE,
@@ -37,7 +37,7 @@ export function toObjectContaining<T>(
 
         // Serializable[]
         if (Array.isArray(value[prop])) {
-          record[prop] = (value[prop] as JSONArray).map((v: JSONValue) => {
+          record[prop] = (value[prop] as JSONValue[]).map((v: JSONValue) => {
             if (!isObject(v)) {
               throw new Error(ERROR_TO_OBJECT_CONTAINING_INVALID_SUB_VALUE);
             }

--- a/strategy/to_json/default.ts
+++ b/strategy/to_json/default.ts
@@ -2,7 +2,7 @@
 
 import { JSONValue } from "../../serializable.ts";
 
-/** Use the default replacer logic 
+/** Use the default replacer logic
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#The_replacer_parameter
 */
 export function toJSONDefault(value: any): JSONValue {

--- a/strategy/utils.ts
+++ b/strategy/utils.ts
@@ -4,8 +4,8 @@ import { isNewable } from "./_utils.ts";
 
 export type NewSerializable<T> = T & (new () => Serializable);
 type FunctionSerializable = () => Serializable;
-/** for strategies can be a provided function 
- * returning a `new` constructed type or 
+/** for strategies can be a provided function
+ * returning a `new` constructed type or
  * a raw type to be constructed  */
 export type SerializableConstructor<T> =
   | NewSerializable<T>


### PR DESCRIPTION
**Description**
Mostly cleaning up some code 

- fixes #127 


**Proposed changes in this PR**
- removes array as a strategy, use `composeStrategy` instead
- `fmt` with deno@1.10.3
- turn off unstable code coverage
- remove `JSONArray` for `JSONValue[]`

**Things to look at**

- [x] Test coverage
- [x] Code Style
- [x] Documentation (`README.md`, `doc/`, `examples/`, etc..)
