### PR TITLE
add type guard for callable types with deno@1.11.1

### DIFF
--- a/.github/workflows/scripts/npm_release_files/babel_ts_serialize.ts
+++ b/.github/workflows/scripts/npm_release_files/babel_ts_serialize.ts
@@ -12,6 +12,7 @@ const { code } = await p.status();
 
 if (code === 0) {
   const source = await p.output();
+  // deno-lint-ignore no-explicit-any
   const { transform } = babelCore as any;
   const { code } = transform(
     new TextDecoder().decode(source),

--- a/.github/workflows/scripts/npm_release_files/ts_serialize.d.ts
+++ b/.github/workflows/scripts/npm_release_files/ts_serialize.d.ts
@@ -27,7 +27,7 @@ declare module "@gamebridgeai/ts_serialize" {
   /** to be implemented by external authors on their models  */
   export interface FromJSON {
     /** to Serializable Object */
-    fromJSON(json: string | JSONValue | unknown): this;
+    fromJSON(json: JSONValue): this;
   }
   /** to be implemented by external authors on their models  */
   export interface Serialize {
@@ -41,7 +41,7 @@ declare module "@gamebridgeai/ts_serialize" {
     /** to JSON String */
     public toJSON(): string;
     /** to Serializable */
-    public fromJSON(json: string | JSONValue | unknown): this;
+    public fromJSON(json: JSONValue): this;
     /** to JSONObject */
     public tsSerialize(): JSONObject;
   }
@@ -117,12 +117,12 @@ declare module "@gamebridgeai/ts_serialize" {
   export type PropertyValueTest = (propertyValue: unknown) => boolean;
 
   export type ResolverFunction = (
-    json: string | JSONValue | unknown,
+    json: JSONValue,
   ) => Serializable;
 
   export function polymorphicClassFromJSON<T extends Serializable>(
     classPrototype: unknown & { prototype: T },
-    json: string | JSONValue | unknown,
+    json: JSONValue,
   ): T;
   /** Adds a class and a resolver function to the resolver map */
   export function PolymorphicResolver(

--- a/.github/workflows/scripts/npm_release_files/ts_serialize.d.ts
+++ b/.github/workflows/scripts/npm_release_files/ts_serialize.d.ts
@@ -27,9 +27,7 @@ declare module "@gamebridgeai/ts_serialize" {
   /** to be implemented by external authors on their models  */
   export interface FromJSON {
     /** to Serializable Object */
-    /** `Object` is used with Angular's HttpClient */
-    // deno-lint-ignore ban-types
-    fromJSON(json: string | JSONValue | Object): this;
+    fromJSON(json: string | JSONValue | unknown): this;
   }
   /** to be implemented by external authors on their models  */
   export interface Serialize {
@@ -43,9 +41,7 @@ declare module "@gamebridgeai/ts_serialize" {
     /** to JSON String */
     public toJSON(): string;
     /** to Serializable */
-    /** `Object` is used with Angular's HttpClient */
-    // deno-lint-ignore ban-types
-    public fromJSON(json: string | JSONValue | Object): this;
+    public fromJSON(json: string | JSONValue | unknown): this;
     /** to JSONObject */
     public tsSerialize(): JSONObject;
   }
@@ -121,16 +117,12 @@ declare module "@gamebridgeai/ts_serialize" {
   export type PropertyValueTest = (propertyValue: unknown) => boolean;
 
   export type ResolverFunction = (
-    /** `Object` is used with Angular's HttpClient */
-    // deno-lint-ignore ban-types
-    json: string | JSONValue | Object,
+    json: string | JSONValue | unknown,
   ) => Serializable;
 
   export function polymorphicClassFromJSON<T extends Serializable>(
     classPrototype: unknown & { prototype: T },
-    /** `Object` is used with Angular's HttpClient */
-    // deno-lint-ignore ban-types
-    json: string | JSONValue | Object,
+    json: string | JSONValue | unknown,
   ): T;
   /** Adds a class and a resolver function to the resolver map */
   export function PolymorphicResolver(

--- a/.github/workflows/scripts/npm_release_files/ts_serialize.d.ts
+++ b/.github/workflows/scripts/npm_release_files/ts_serialize.d.ts
@@ -27,6 +27,8 @@ declare module "@gamebridgeai/ts_serialize" {
   /** to be implemented by external authors on their models  */
   export interface FromJSON {
     /** to Serializable Object */
+    /** `Object` is used with Angular's HttpClient */
+    // deno-lint-ignore ban-types
     fromJSON(json: string | JSONValue | Object): this;
   }
   /** to be implemented by external authors on their models  */
@@ -41,6 +43,8 @@ declare module "@gamebridgeai/ts_serialize" {
     /** to JSON String */
     public toJSON(): string;
     /** to Serializable */
+    /** `Object` is used with Angular's HttpClient */
+    // deno-lint-ignore ban-types
     public fromJSON(json: string | JSONValue | Object): this;
     /** to JSONObject */
     public tsSerialize(): JSONObject;
@@ -49,14 +53,9 @@ declare module "@gamebridgeai/ts_serialize" {
   type NewSerializable<T> = T & (new () => Serializable);
   type FunctionSerializable = () => Serializable;
 
-  /** for strategies */
-  export type SerializableConstructor<T> =
-    | NewSerializable<T>
-    | FunctionSerializable;
-
   /** get new strategy type arguments */
-  export function getNewSerializable<T>(
-    type: SerializableConstructor<T>,
+  export function getNewSerializable(
+    type: unknown,
   ): Serializable;
 
   /** Functions used when hydrating data */
@@ -93,13 +92,13 @@ declare module "@gamebridgeai/ts_serialize" {
   ): FromJSONStrategy | ToJSONStrategy;
 
   /** revive data using `fromJSON` on a subclass type */
-  export function toSerializable<T>(
-    type: SerializableConstructor<T>,
+  export function toSerializable(
+    type: unknown,
   ): FromJSONStrategy;
 
   /** revive data from `{k: v}` using `fromJSON` on a subclass type `v` */
   export function toObjectContaining<T>(
-    type: SerializableConstructor<T>,
+    type: unknown,
   ): FromJSONStrategy;
 
   /** convert `{ [_: string]: Serializable }` to `{ [_: string]: Serializable.toSerialize() }` */
@@ -120,11 +119,15 @@ declare module "@gamebridgeai/ts_serialize" {
   export type PropertyValueTest = (propertyValue: unknown) => boolean;
 
   export type ResolverFunction = (
+    /** `Object` is used with Angular's HttpClient */
+    // deno-lint-ignore ban-types
     json: string | JSONValue | Object,
   ) => Serializable;
 
   export function polymorphicClassFromJSON<T extends Serializable>(
-    classPrototype: Object & { prototype: T },
+    classPrototype: unknown & { prototype: T },
+    /** `Object` is used with Angular's HttpClient */
+    // deno-lint-ignore ban-types
     json: string | JSONValue | Object,
   ): T;
   /** Adds a class and a resolver function to the resolver map */
@@ -145,6 +148,6 @@ declare module "@gamebridgeai/ts_serialize" {
 
   export function PolymorphicSwitch<T>(
     initializerFunction: InitializerFunction,
-    value: Exclude<T, Function>,
+    value: Exclude<T, PropertyValueTest>,
   ): PropertyDecorator;
 }

--- a/.github/workflows/scripts/npm_release_files/ts_serialize.d.ts
+++ b/.github/workflows/scripts/npm_release_files/ts_serialize.d.ts
@@ -39,7 +39,7 @@ declare module "@gamebridgeai/ts_serialize" {
   /** Adds methods for serialization */
   export abstract class Serializable {
     /** key transform functionality */
-    public tsTransformKey?(key: string): string;
+    public tsTransformKey(key: string): string;
     /** to JSON String */
     public toJSON(): string;
     /** to Serializable */

--- a/.github/workflows/scripts/npm_release_files/ts_serialize.d.ts
+++ b/.github/workflows/scripts/npm_release_files/ts_serialize.d.ts
@@ -59,9 +59,11 @@ declare module "@gamebridgeai/ts_serialize" {
   ): Serializable;
 
   /** Functions used when hydrating data */
+  // deno-lint-ignore no-explicit-any
   export type FromJSONStrategy = (value: JSONValue) => any;
 
   /** Functions used when dehydrating data */
+  // deno-lint-ignore no-explicit-any
   export type ToJSONStrategy = (value: any) => JSONValue;
 
   /** string/symbol property name or options for (de)serializing values */
@@ -112,7 +114,7 @@ declare module "@gamebridgeai/ts_serialize" {
   /** Changed from
    * @see https://weblog.west-wind.com/posts/2014/Jan/06/JavaScript-JSON-Date-Parsing-and-real-Dates
    */
-  export function iso8601Date(input: JSONValue): any;
+  export function iso8601Date(input: JSONValue): Date;
 
   export type InitializerFunction = () => Serializable;
 

--- a/.github/workflows/ts_serialize_release.yml
+++ b/.github/workflows/ts_serialize_release.yml
@@ -23,18 +23,21 @@ jobs:
         uses: denolib/setup-deno@v2
         with:
           deno-version: ${{ matrix.deno }}
+
+      - name: Deno lint
+        run: deno lint
       
-      - name: Deno Format Check
+      - name: Deno format check
         run: deno fmt --check
         if: matrix.os != 'windows-latest'
 
-      - name: Cache Dependencies
+      - name: Cache dependencies
         run: deno cache test_deps.ts
 
-      - name: Run Deno Tests with coverage
+      - name: Run deno dests with coverage
         run: deno test --coverage=coverage --unstable
 
-      - name: lcov test coverage
+      - name: LCOV test coverage
         run: deno coverage --unstable coverage --lcov > coverage.lcov
         if: matrix.os == 'ubuntu-latest'
 
@@ -47,7 +50,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
         if: matrix.os == 'ubuntu-latest'
 
-      - name: Run package.json Generation Tests
+      - name: Run package.json generation tests
         run: .github/workflows/scripts/npm_release_files/create_npm_package_file_test.sh
 
   build:

--- a/.github/workflows/ts_serialize_release.yml
+++ b/.github/workflows/ts_serialize_release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Cache dependencies
         run: deno cache test_deps.ts
 
-      - name: Run deno dests with coverage
+      - name: Run deno tests with coverage
         run: deno test --coverage=coverage --unstable
 
       - name: LCOV test coverage

--- a/.github/workflows/ts_serialize_tests.yml
+++ b/.github/workflows/ts_serialize_tests.yml
@@ -28,6 +28,9 @@ jobs:
         uses: denolib/setup-deno@v2
         with:
           deno-version: ${{ matrix.deno }}
+
+      - name: Deno lint
+        run: deno lint
       
       - name: Deno format check
         run: deno fmt --check

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,1 +1,5 @@
-{ "deno.enable": true }
+{ 
+    "deno.enable": true,
+    "deno.lint": true,
+    "deno.unstable": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
-{ 
-    "deno.enable": true,
-    "deno.lint": true,
-    "deno.unstable": true
+{
+  "deno.enable": true,
+  "deno.lint": true,
+  "deno.unstable": true
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to
 - turn off unstable code coverage
 - remove JSONArray for JSONValue[]
 - add type guard in `getNewSerializable` fixing compile issue
+- address lint issues
 
 ## [v1.3.1] - 2021-03-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 - fmt with deno@1.10.3
 - turn off unstable code coverage
 - remove JSONArray for JSONValue[]
+- add type guard in `getNewSerializable` fixing compile issue
 
 ## [v1.3.1] - 2021-03-14
 

--- a/benchmarks/_one_property_test.ts
+++ b/benchmarks/_one_property_test.ts
@@ -7,7 +7,7 @@ import { SerializeProperty } from "../serialize_property.ts";
 
 class Root extends Serializable {
   @SerializeProperty()
-  property: string = "default";
+  property = "default";
 }
 
 const input = { property: "from_input" };

--- a/docs/serializable.md
+++ b/docs/serializable.md
@@ -212,13 +212,13 @@ While `@SerializeProperty` is handy with to and from JSON strategies, it can
 still be verbose to declare the strategies for each property. You can define
 your owndecorator functions to wrap `@SerializeProperty` and provide the
 `toJSONStrategy` and `fromJSONStrategy`. An example short cut is providing a
-`type` to use with `toSerializable`. `SerializableConstructor` and
-`getNewSerializable` are provided to allow a raw serializable type or a function
-that returns a constructed serializable type enabling constructor arguments:
+`type` to use with `toSerializable`. `getNewSerializable` is provided to allow a
+raw serializable type or a function that returns a constructed serializable type
+enabling constructor arguments:
 
 ```ts
-export function DeserializeAs<T>(
-  type: SerializableConstructor<T>,
+export function DeserializeAs(
+  type: unknown,
 ): PropertyDecorator {
   return SerializeProperty({ fromJSONStrategy: toSerializable(getNewSerializable(type)) });
 }

--- a/error_messages.ts
+++ b/error_messages.ts
@@ -22,3 +22,6 @@ export const ERROR_TO_OBJECT_CONTAINING_INVALID_VALUE =
 
 export const ERROR_TO_OBJECT_CONTAINING_INVALID_SUB_VALUE =
   "The sub-value is not an object";
+
+export const ERROR_GET_NEW_SERIALIZABLE_SERIALIZABLE_NOT_RETURNED =
+  "The provided input is not Serializable or a function.";

--- a/error_messages_test.ts
+++ b/error_messages_test.ts
@@ -21,7 +21,10 @@ test({
       typeof mod.ERROR_TO_OBJECT_CONTAINING_INVALID_SUB_VALUE,
       "string",
     );
-
-    assertEquals(Object.keys(mod).length, 8);
+    assertEquals(
+      typeof mod.ERROR_GET_NEW_SERIALIZABLE_SERIALIZABLE_NOT_RETURNED,
+      "string",
+    );
+    assertEquals(Object.keys(mod).length, 9);
   },
 });

--- a/examples/node/node_tests.ts
+++ b/examples/node/node_tests.ts
@@ -163,7 +163,7 @@ abstract class AbstractClass extends Serializable {
   // Property name can be whatever, even an inaccessible symbol
   @PolymorphicResolver
   public static [Symbol()](
-    json: string | JSONValue | Object,
+    json: string | JSONValue | unknown,
   ): Serializable {
     const inputObject = new ResolverHelperClass().fromJSON(json);
 

--- a/examples/node/node_tests.ts
+++ b/examples/node/node_tests.ts
@@ -1,5 +1,7 @@
 // Copyright 2018-2021 Gamebridge.ai authors. All rights reserved. MIT license.
 
+// deno-lint-ignore-file
+
 import {
   composeStrategy,
   createDateStrategy,

--- a/examples/node/node_tests.ts
+++ b/examples/node/node_tests.ts
@@ -163,7 +163,7 @@ abstract class AbstractClass extends Serializable {
   // Property name can be whatever, even an inaccessible symbol
   @PolymorphicResolver
   public static [Symbol()](
-    json: string | JSONValue | unknown,
+    json: JSONValue,
   ): Serializable {
     const inputObject = new ResolverHelperClass().fromJSON(json);
 

--- a/mod.ts
+++ b/mod.ts
@@ -39,5 +39,3 @@ export type {
 } from "./polymorphic.ts";
 
 export { getNewSerializable } from "./strategy/utils.ts";
-/** types */
-export type { SerializableConstructor } from "./strategy/utils.ts";

--- a/polymorphic.ts
+++ b/polymorphic.ts
@@ -45,7 +45,7 @@ export function PolymorphicResolver(
 }
 
 export type ResolverFunction = (
-  json: string | JSONValue | unknown,
+  json: JSONValue,
 ) => Serializable | null;
 
 /** Map of parent class constructors to functions that take in a JSON input and output a class instance that inherits Serializable */
@@ -157,7 +157,7 @@ function registerPolymorphicSwitch<T>(
 /** Return a resolved class type by testing the value of a property key */
 function resolvePolymorphicSwitch(
   parentClassConstructor: unknown,
-  json: string | JSONValue | unknown,
+  json: JSONValue,
 ): Serializable | null {
   const classOptionsSet = POLYMORPHIC_SWITCH_MAP.get(
     parentClassConstructor,
@@ -211,7 +211,7 @@ function resolvePolymorphicSwitch(
  */
 export function polymorphicClassFromJSON<T extends Serializable>(
   classPrototype: unknown & { prototype: T },
-  json: string | JSONValue | unknown,
+  json: JSONValue,
 ): T {
   return resolvePolymorphicClass(classPrototype, json).fromJSON(json);
 }
@@ -221,7 +221,7 @@ export function polymorphicClassFromJSON<T extends Serializable>(
  */
 function resolvePolymorphicClass<T extends Serializable>(
   classPrototype: unknown & { prototype: T },
-  json: string | JSONValue | unknown,
+  json: JSONValue,
 ): T {
   const classResolver = POLYMORPHIC_RESOLVER_MAP.get(classPrototype);
   if (classResolver) {

--- a/polymorphic.ts
+++ b/polymorphic.ts
@@ -45,9 +45,7 @@ export function PolymorphicResolver(
 }
 
 export type ResolverFunction = (
-  /** `Object` is used with Angular's HttpClient */
-  // deno-lint-ignore ban-types
-  json: string | JSONValue | Object,
+  json: string | JSONValue | unknown,
 ) => Serializable | null;
 
 /** Map of parent class constructors to functions that take in a JSON input and output a class instance that inherits Serializable */
@@ -159,9 +157,7 @@ function registerPolymorphicSwitch<T>(
 /** Return a resolved class type by testing the value of a property key */
 function resolvePolymorphicSwitch(
   parentClassConstructor: unknown,
-  /** `Object` is used with Angular's HttpClient */
-  // deno-lint-ignore ban-types
-  json: string | JSONValue | Object,
+  json: string | JSONValue | unknown,
 ): Serializable | null {
   const classOptionsSet = POLYMORPHIC_SWITCH_MAP.get(
     parentClassConstructor,
@@ -215,9 +211,7 @@ function resolvePolymorphicSwitch(
  */
 export function polymorphicClassFromJSON<T extends Serializable>(
   classPrototype: unknown & { prototype: T },
-  /** `Object` is used with Angular's HttpClient */
-  // deno-lint-ignore ban-types
-  json: string | JSONValue | Object,
+  json: string | JSONValue | unknown,
 ): T {
   return resolvePolymorphicClass(classPrototype, json).fromJSON(json);
 }
@@ -227,9 +221,7 @@ export function polymorphicClassFromJSON<T extends Serializable>(
  */
 function resolvePolymorphicClass<T extends Serializable>(
   classPrototype: unknown & { prototype: T },
-  /** `Object` is used with Angular's HttpClient */
-  // deno-lint-ignore ban-types
-  json: string | JSONValue | Object,
+  json: string | JSONValue | unknown,
 ): T {
   const classResolver = POLYMORPHIC_RESOLVER_MAP.get(classPrototype);
   if (classResolver) {

--- a/polymorphic.ts
+++ b/polymorphic.ts
@@ -33,7 +33,7 @@ export type InitializerFunction = () => Serializable;
 
 /** \@PolymorphicResolver method decorator */
 export function PolymorphicResolver(
-  target: Object,
+  target: unknown,
   propertyKey: string | symbol,
 ): void {
   registerPolymorphicResolver(
@@ -45,15 +45,17 @@ export function PolymorphicResolver(
 }
 
 export type ResolverFunction = (
+  /** `Object` is used with Angular's HttpClient */
+  // deno-lint-ignore ban-types
   json: string | JSONValue | Object,
 ) => Serializable | null;
 
 /** Map of parent class constructors to functions that take in a JSON input and output a class instance that inherits Serializable */
-const POLYMORPHIC_RESOLVER_MAP = new Map<Object, ResolverFunction>();
+const POLYMORPHIC_RESOLVER_MAP = new Map<unknown, ResolverFunction>();
 
 /** Adds a class and a resolver function to the resolver map */
 function registerPolymorphicResolver(
-  classPrototype: Object,
+  classPrototype: unknown,
   resolver: ResolverFunction,
 ): void {
   POLYMORPHIC_RESOLVER_MAP.set(classPrototype, resolver);
@@ -71,7 +73,7 @@ export function PolymorphicSwitch(
 
 export function PolymorphicSwitch<T>(
   initializerFunction: InitializerFunction,
-  value: Exclude<T, Function>,
+  value: Exclude<T, PropertyValueTest>,
 ): PropertyDecorator;
 
 export function PolymorphicSwitch(
@@ -79,7 +81,7 @@ export function PolymorphicSwitch(
   valueOrTest: PropertyValueTest | unknown,
 ): PropertyDecorator {
   return function _PolymorphicSwitch(
-    target: Object, // The class it's self
+    target: unknown, // The class it's self
     propertyKey: string | symbol,
   ) {
     registerPolymorphicSwitch(
@@ -92,10 +94,10 @@ export function PolymorphicSwitch(
   };
 }
 
-const POLYMORPHIC_SWITCH_MAP = new Map<Object, Set<PolymorphicClassOptions>>();
+const POLYMORPHIC_SWITCH_MAP = new Map<unknown, Set<PolymorphicClassOptions>>();
 
 type PolymorphicClassOptions = {
-  classDefinition: Object;
+  classDefinition: unknown;
   propertyKey: string | symbol;
   propertyValueTest: PropertyValueTest;
   initializer: InitializerFunction;
@@ -107,24 +109,24 @@ export type PropertyValueTest = (propertyValue: unknown) => boolean;
  * Registers a set of polymorphic class options with a parent class
  */
 function registerPolymorphicSwitch<T>(
-  parentClassConstructor: Object,
-  classDefinition: Object,
+  parentClassConstructor: unknown,
+  classDefinition: unknown,
   propertyKey: string | symbol,
   propertyValueTest: PropertyValueTest,
   initializer: InitializerFunction,
 ): void;
 
 function registerPolymorphicSwitch<T>(
-  parentClassConstructor: Object,
-  classDefinition: Object,
+  parentClassConstructor: unknown,
+  classDefinition: unknown,
   propertyKey: string | symbol,
-  propertyValue: Exclude<T, Function>,
+  propertyValue: Exclude<T, PropertyValueTest>,
   initializer: InitializerFunction,
 ): void;
 
 function registerPolymorphicSwitch<T>(
-  parentClassConstructor: Object,
-  classDefinition: Object,
+  parentClassConstructor: unknown,
+  classDefinition: unknown,
   propertyKey: string | symbol,
   valueOrTest: PropertyValueTest | unknown,
   initializer: InitializerFunction,
@@ -156,7 +158,9 @@ function registerPolymorphicSwitch<T>(
 
 /** Return a resolved class type by testing the value of a property key */
 function resolvePolymorphicSwitch(
-  parentClassConstructor: Object,
+  parentClassConstructor: unknown,
+  /** `Object` is used with Angular's HttpClient */
+  // deno-lint-ignore ban-types
   json: string | JSONValue | Object,
 ): Serializable | null {
   const classOptionsSet = POLYMORPHIC_SWITCH_MAP.get(
@@ -210,7 +214,9 @@ function resolvePolymorphicSwitch(
  * appropriate class, then deserialize the input using Serializable#fromJSON, returning the result
  */
 export function polymorphicClassFromJSON<T extends Serializable>(
-  classPrototype: Object & { prototype: T },
+  classPrototype: unknown & { prototype: T },
+  /** `Object` is used with Angular's HttpClient */
+  // deno-lint-ignore ban-types
   json: string | JSONValue | Object,
 ): T {
   return resolvePolymorphicClass(classPrototype, json).fromJSON(json);
@@ -220,7 +226,9 @@ export function polymorphicClassFromJSON<T extends Serializable>(
  * and input, and returns the initialized child class. Throws an exception if no class can be resolved
  */
 function resolvePolymorphicClass<T extends Serializable>(
-  classPrototype: Object & { prototype: T },
+  classPrototype: unknown & { prototype: T },
+  /** `Object` is used with Angular's HttpClient */
+  // deno-lint-ignore ban-types
   json: string | JSONValue | Object,
 ): T {
   const classResolver = POLYMORPHIC_RESOLVER_MAP.get(classPrototype);

--- a/polymorphic_test.ts
+++ b/polymorphic_test.ts
@@ -306,9 +306,9 @@ test({
   fn() {
     abstract class AbstractClass extends Serializable {}
 
-    class TestClass extends AbstractClass {
+    class _TestClass extends AbstractClass {
       @SerializeProperty()
-      @PolymorphicSwitch(() => new TestClass(), "TestClass")
+      @PolymorphicSwitch(() => new _TestClass(), "TestClass")
       public class = "TestClass";
 
       @SerializeProperty()
@@ -392,7 +392,7 @@ test({
       public someProperty = "original value";
     }
 
-    const testData = { some_class: "TestClass", someProperty: "some value" };
+    const testData = { "some_class": "TestClass", someProperty: "some value" };
     const polyClass = polymorphicClassFromJSON(AbstractClass, testData);
 
     assert(polyClass instanceof TestClass);

--- a/polymorphic_test.ts
+++ b/polymorphic_test.ts
@@ -41,7 +41,7 @@ test({
       // Property name can be whatever, even an inaccessible symbol
       @PolymorphicResolver
       public static [Symbol()](
-        json: string | JSONValue | unknown,
+        json: JSONValue,
       ): Serializable {
         const inputObject = new ResolverHelperClass().fromJSON(json);
 
@@ -82,7 +82,7 @@ test({
       // Property name can be whatever, even an inaccessible symbol
       @PolymorphicResolver
       public static [Symbol()](
-        json: string | JSONValue | unknown,
+        json: JSONValue,
       ): Serializable {
         const inputObject = new ResolverHelperClass().fromJSON(json);
 

--- a/polymorphic_test.ts
+++ b/polymorphic_test.ts
@@ -41,6 +41,8 @@ test({
       // Property name can be whatever, even an inaccessible symbol
       @PolymorphicResolver
       public static [Symbol()](
+        /** `Object` is used with Angular's HttpClient */
+        // deno-lint-ignore ban-types
         json: string | JSONValue | Object,
       ): Serializable {
         const inputObject = new ResolverHelperClass().fromJSON(json);
@@ -82,6 +84,8 @@ test({
       // Property name can be whatever, even an inaccessible symbol
       @PolymorphicResolver
       public static [Symbol()](
+        /** `Object` is used with Angular's HttpClient */
+        // deno-lint-ignore ban-types
         json: string | JSONValue | Object,
       ): Serializable {
         const inputObject = new ResolverHelperClass().fromJSON(json);

--- a/polymorphic_test.ts
+++ b/polymorphic_test.ts
@@ -41,9 +41,7 @@ test({
       // Property name can be whatever, even an inaccessible symbol
       @PolymorphicResolver
       public static [Symbol()](
-        /** `Object` is used with Angular's HttpClient */
-        // deno-lint-ignore ban-types
-        json: string | JSONValue | Object,
+        json: string | JSONValue | unknown,
       ): Serializable {
         const inputObject = new ResolverHelperClass().fromJSON(json);
 
@@ -84,9 +82,7 @@ test({
       // Property name can be whatever, even an inaccessible symbol
       @PolymorphicResolver
       public static [Symbol()](
-        /** `Object` is used with Angular's HttpClient */
-        // deno-lint-ignore ban-types
-        json: string | JSONValue | Object,
+        json: string | JSONValue | unknown,
       ): Serializable {
         const inputObject = new ResolverHelperClass().fromJSON(json);
 

--- a/serializable.ts
+++ b/serializable.ts
@@ -93,7 +93,7 @@ export abstract class Serializable {
   constructor() {
     getOrInitializeDefaultSerializerLogicForParents(this.constructor.prototype);
   }
-  public tsTransformKey?(key: string): string {
+  public tsTransformKey(key: string): string {
     return key;
   }
   public toJSON(): string {

--- a/serializable.ts
+++ b/serializable.ts
@@ -32,9 +32,7 @@ export declare interface ToJSON {
 
 /** reutrns  a new javascript object with transformations */
 export declare interface FromJSON {
-  /** `Object` is used with Angular's HttpClient */
-  // deno-lint-ignore ban-types
-  fromJSON(json: string | JSONValue | Object): this;
+  fromJSON(json: string | JSONValue | unknown): this;
 }
 
 /** returns the javascript object as a `JSONObject` with transformations */
@@ -99,9 +97,7 @@ export abstract class Serializable {
   public toJSON(): string {
     return toJSON(this);
   }
-  /** `Object` is used with Angular's HttpClient */
-  // deno-lint-ignore ban-types
-  public fromJSON(json: string | JSONValue | Object): this {
+  public fromJSON(json: string | JSONValue | unknown): this {
     return fromJSON(this, json);
   }
   public tsSerialize(): JSONObject {
@@ -174,9 +170,7 @@ function toJSON(context: Serializable): string {
 /** Convert from object/string to mapped object on the context */
 function fromJSON<T>(
   context: Serializable,
-  /** `Object` is used with Angular's HttpClient */
-  // deno-lint-ignore ban-types
-  json: string | JSONValue | Object,
+  json: string | JSONValue | unknown,
 ): T {
   const _json = typeof json === "string" ? JSON.parse(json) : json;
   const accumulator: Partial<T> = {};

--- a/serializable.ts
+++ b/serializable.ts
@@ -32,7 +32,7 @@ export declare interface ToJSON {
 
 /** reutrns  a new javascript object with transformations */
 export declare interface FromJSON {
-  fromJSON(json: string | JSONValue | unknown): this;
+  fromJSON(json: JSONValue): this;
 }
 
 /** returns the javascript object as a `JSONObject` with transformations */
@@ -97,7 +97,7 @@ export abstract class Serializable {
   public toJSON(): string {
     return toJSON(this);
   }
-  public fromJSON(json: string | JSONValue | unknown): this {
+  public fromJSON(json: JSONValue): this {
     return fromJSON(this, json);
   }
   public tsSerialize(): JSONObject {
@@ -170,7 +170,7 @@ function toJSON(context: Serializable): string {
 /** Convert from object/string to mapped object on the context */
 function fromJSON<T>(
   context: Serializable,
-  json: string | JSONValue | unknown,
+  json: JSONValue,
 ): T {
   const _json = typeof json === "string" ? JSON.parse(json) : json;
   const accumulator: Partial<T> = {};

--- a/serializable_test.ts
+++ b/serializable_test.ts
@@ -11,10 +11,10 @@ test({
   fn() {
     class TestClass extends Serializable {
       @SerializeProperty()
-      public test: number = 99;
+      public test = 99;
 
       @SerializeProperty("test_one")
-      public test1: number = 100;
+      public test1 = 100;
     }
     const testObj = new TestClass();
     assert(testObj instanceof Serializable);
@@ -279,7 +279,7 @@ test({
   name: "toPojo errors with no context",
   fn() {
     try {
-      toPojo({});
+      toPojo({} as Serializable);
       fail("to Pojo did not error with no context");
     } catch (e) {
       assertEquals(

--- a/serialize_property.ts
+++ b/serialize_property.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2021 Gamebridge.ai authors. All rights reserved. MIT license.
 
-import { SERIALIZABLE_CLASS_MAP } from "./serializable.ts";
+import { Serializable, SERIALIZABLE_CLASS_MAP } from "./serializable.ts";
 
 import { SerializePropertyOptionsMap } from "./serialize_property_options_map.ts";
 import {
@@ -158,10 +158,17 @@ function getDecoratorArgumentOptions(
     };
   }
 
+  if (typeof decoratorArguments.serializedKey === "string") {
+    return decoratorArguments as SerializePropertyArgumentObject;
+  }
+
   // Use inherited tsTransformKey strategy or default no change transform
   // to transform property key decoratorArguments.serializedKey will override
   return {
-    serializedKey: (target as any).tsTransformKey(String(propertyName)),
-    ...decoratorArguments,
+    serializedKey: (target as Serializable).tsTransformKey(
+      String(propertyName),
+    ),
+    fromJSONStrategy: decoratorArguments.fromJSONStrategy,
+    toJSONStrategy: decoratorArguments.toJSONStrategy,
   };
 }

--- a/serialize_property_test.ts
+++ b/serialize_property_test.ts
@@ -58,7 +58,7 @@ test({
   fn() {
     try {
       const TEST = Symbol("test");
-      class Test extends Serializable {
+      class _Test extends Serializable {
         @SerializeProperty()
         [TEST] = "toJSON";
       }
@@ -195,7 +195,7 @@ test({
   fn() {
     class Test extends Serializable {
       @SerializeProperty()
-      array!: any[];
+      array!: unknown[];
     }
     const testObj = new Test().fromJSON(
       `{"array":["worked",0,{"subObj":["cool"]}]}`,
@@ -248,7 +248,7 @@ test({
   name: "Errors on duplicate map keys",
   fn() {
     try {
-      class Test extends Serializable {
+      class _Test extends Serializable {
         @SerializeProperty("serialize_me")
         serializeMe = "nice";
         @SerializeProperty("serialize_me")

--- a/strategy/_utils.ts
+++ b/strategy/_utils.ts
@@ -1,10 +1,6 @@
 // Copyright 2018-2021 Gamebridge.ai authors. All rights reserved. MIT license.
 
-import {
-  FunctionSerializable,
-  NewSerializable,
-  SerializableConstructor,
-} from "./utils.ts";
+import { FunctionSerializable, NewSerializable } from "./utils.ts";
 
 /** for strategy values */
 export function isObject(obj: unknown): obj is Record<string, unknown> {
@@ -13,7 +9,7 @@ export function isObject(obj: unknown): obj is Record<string, unknown> {
 
 /** for strategy type arguments */
 export function isNewable<T>(
-  type: SerializableConstructor<T>,
+  type: unknown,
 ): type is NewSerializable<T> {
   return (type && typeof type === "function" && type.prototype &&
     type.prototype.constructor) === type;

--- a/strategy/_utils.ts
+++ b/strategy/_utils.ts
@@ -7,7 +7,7 @@ import {
 } from "./utils.ts";
 
 /** for strategy values */
-export function isObject(obj: any): obj is Record<string, any> {
+export function isObject(obj: unknown): obj is Record<string, unknown> {
   return Object.prototype.toString.call(obj) === "[object Object]";
 }
 
@@ -20,8 +20,8 @@ export function isNewable<T>(
 }
 
 /** for strategy type arguments */
-export function isCallable<T>(
-  type: SerializableConstructor<T>,
+export function isFunctionSerializable(
+  type: unknown,
 ): type is FunctionSerializable {
   return typeof type === "function";
 }

--- a/strategy/_utils.ts
+++ b/strategy/_utils.ts
@@ -1,6 +1,10 @@
 // Copyright 2018-2021 Gamebridge.ai authors. All rights reserved. MIT license.
 
-import { NewSerializable, SerializableConstructor } from "./utils.ts";
+import {
+  FunctionSerializable,
+  NewSerializable,
+  SerializableConstructor,
+} from "./utils.ts";
 
 /** for strategy values */
 export function isObject(obj: any): obj is Record<string, any> {
@@ -13,4 +17,11 @@ export function isNewable<T>(
 ): type is NewSerializable<T> {
   return (type && typeof type === "function" && type.prototype &&
     type.prototype.constructor) === type;
+}
+
+/** for strategy type arguments */
+export function isCallable<T>(
+  type: SerializableConstructor<T>,
+): type is FunctionSerializable {
+  return typeof type === "function";
 }

--- a/strategy/compose_strategy.ts
+++ b/strategy/compose_strategy.ts
@@ -12,14 +12,13 @@ export type ToJSONStrategy = (value: any) => JSONValue;
  */
 export function composeStrategy(
   ...fns: (
-    | FromJSONStrategy
     | ToJSONStrategy
+    | FromJSONStrategy
   )[]
 ): FromJSONStrategy | ToJSONStrategy {
-  return function _composeStrategy(val: any): any {
-    return fns.reduce(
-      (acc: any, fn: FromJSONStrategy | ToJSONStrategy) => fn(acc),
-      val,
-    );
+  return function _composeStrategy(
+    val: any,
+  ): unknown {
+    return fns.reduce((acc, fn) => fn(acc), val);
   };
 }

--- a/strategy/compose_strategy.ts
+++ b/strategy/compose_strategy.ts
@@ -21,7 +21,7 @@ export function composeStrategy(
   return function _composeStrategy(
     // deno-lint-ignore no-explicit-any
     val: any,
-  ): unknown {
+  ): JSONValue | unknown {
     return fns.reduce((acc, fn) => fn(acc), val);
   };
 }

--- a/strategy/compose_strategy.ts
+++ b/strategy/compose_strategy.ts
@@ -2,9 +2,11 @@
 import { JSONValue } from "../serializable.ts";
 
 /** Functions used when hydrating data */
+// deno-lint-ignore no-explicit-any
 export type FromJSONStrategy = (value: JSONValue) => any;
 
 /** Functions used when dehydrating data */
+// deno-lint-ignore no-explicit-any
 export type ToJSONStrategy = (value: any) => JSONValue;
 
 /** Function to build a `fromJSONStrategy` or `toJSONStrategy`.
@@ -17,6 +19,7 @@ export function composeStrategy(
   )[]
 ): FromJSONStrategy | ToJSONStrategy {
   return function _composeStrategy(
+    // deno-lint-ignore no-explicit-any
     val: any,
   ): unknown {
     return fns.reduce((acc, fn) => fn(acc), val);

--- a/strategy/from_json/date.ts
+++ b/strategy/from_json/date.ts
@@ -18,7 +18,7 @@ export function createDateStrategy(regex: RegExp): FromJSONStrategy {
 }
 
 /** Test a string for a ISO 8601 Date */
-export function iso8601Date(input: JSONValue): any {
+export function iso8601Date(input: JSONValue): Date {
   /** a provided regex to deal with iso formats
    * @example 2008-08-30T01:45:36
    * @example 2008-08-30T01:45:36.123Z

--- a/strategy/from_json/default.ts
+++ b/strategy/from_json/default.ts
@@ -1,7 +1,6 @@
 // Copyright 2018-2021 Gamebridge.ai authors. All rights reserved. MIT license.
-import { JSONValue } from "../../serializable.ts";
 
 /** typed function */
-export function fromJSONDefault(value: JSONValue): any {
+export function fromJSONDefault<T>(value: T): T {
   return value;
 }

--- a/strategy/from_json/to_object_containing.ts
+++ b/strategy/from_json/to_object_containing.ts
@@ -7,11 +7,11 @@ import {
   ERROR_TO_OBJECT_CONTAINING_INVALID_VALUE,
 } from "../../error_messages.ts";
 import { isObject } from "../_utils.ts";
-import { getNewSerializable, SerializableConstructor } from "../utils.ts";
+import { getNewSerializable } from "../utils.ts";
 
 /** revive data from `{k: v}` using `fromJSON` on a subclass type `v` */
 export function toObjectContaining<T>(
-  type: SerializableConstructor<T>,
+  type: unknown,
 ): FromJSONStrategy {
   return function _toObjectContaining(
     value: JSONValue,

--- a/strategy/from_json/to_object_containing.ts
+++ b/strategy/from_json/to_object_containing.ts
@@ -10,7 +10,7 @@ import { isObject } from "../_utils.ts";
 import { getNewSerializable } from "../utils.ts";
 
 /** revive data from `{k: v}` using `fromJSON` on a subclass type `v` */
-export function toObjectContaining<T>(
+export function toObjectContaining(
   type: unknown,
 ): FromJSONStrategy {
   return function _toObjectContaining(

--- a/strategy/from_json/to_serializable.ts
+++ b/strategy/from_json/to_serializable.ts
@@ -5,7 +5,7 @@ import { FromJSONStrategy } from "../compose_strategy.ts";
 import { getNewSerializable } from "../utils.ts";
 
 /** revive data using `fromJSON` on a subclass type */
-export function toSerializable<T>(
+export function toSerializable(
   type: unknown,
 ): FromJSONStrategy {
   return function _toSerializable(

--- a/strategy/from_json/to_serializable.ts
+++ b/strategy/from_json/to_serializable.ts
@@ -2,11 +2,11 @@
 
 import { JSONValue, Serializable } from "../../serializable.ts";
 import { FromJSONStrategy } from "../compose_strategy.ts";
-import { getNewSerializable, SerializableConstructor } from "../utils.ts";
+import { getNewSerializable } from "../utils.ts";
 
 /** revive data using `fromJSON` on a subclass type */
 export function toSerializable<T>(
-  type: SerializableConstructor<T>,
+  type: unknown,
 ): FromJSONStrategy {
   return function _toSerializable(
     value: JSONValue,

--- a/strategy/to_json/default.ts
+++ b/strategy/to_json/default.ts
@@ -1,10 +1,8 @@
 // Copyright 2018-2021 Gamebridge.ai authors. All rights reserved. MIT license.
 
-import { JSONValue } from "../../serializable.ts";
-
 /** Use the default replacer logic
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#The_replacer_parameter
 */
-export function toJSONDefault(value: any): JSONValue {
+export function toJSONDefault<T>(value: T): T {
   return value;
 }

--- a/strategy/utils.ts
+++ b/strategy/utils.ts
@@ -5,16 +5,9 @@ import { ERROR_GET_NEW_SERIALIZABLE_SERIALIZABLE_NOT_RETURNED } from "../error_m
 
 export type NewSerializable<T> = T & (new () => Serializable);
 export type FunctionSerializable = () => Serializable;
-/** for strategies can be a provided function
- * returning a `new` constructed type or
- * a raw type to be constructed  */
-export type SerializableConstructor<T> =
-  | NewSerializable<T>
-  | FunctionSerializable;
-
 /** get new strategy type arguments */
 export function getNewSerializable<T>(
-  type: SerializableConstructor<T>,
+  type: unknown,
 ): Serializable {
   if (isNewable(type)) {
     return new type();

--- a/strategy/utils.ts
+++ b/strategy/utils.ts
@@ -6,7 +6,7 @@ import { ERROR_GET_NEW_SERIALIZABLE_SERIALIZABLE_NOT_RETURNED } from "../error_m
 export type NewSerializable<T> = T & (new () => Serializable);
 export type FunctionSerializable = () => Serializable;
 /** get new strategy type arguments */
-export function getNewSerializable<T>(
+export function getNewSerializable(
   type: unknown,
 ): Serializable {
   if (isNewable(type)) {

--- a/strategy/utils.ts
+++ b/strategy/utils.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2021 Gamebridge.ai authors. All rights reserved. MIT license.
 import { Serializable } from "../serializable.ts";
-import { isCallable, isNewable } from "./_utils.ts";
+import { isFunctionSerializable, isNewable } from "./_utils.ts";
 import { ERROR_GET_NEW_SERIALIZABLE_SERIALIZABLE_NOT_RETURNED } from "../error_messages.ts";
 
 export type NewSerializable<T> = T & (new () => Serializable);
@@ -18,7 +18,7 @@ export function getNewSerializable<T>(
 ): Serializable {
   if (isNewable(type)) {
     return new type();
-  } else if (isCallable(type)) {
+  } else if (isFunctionSerializable(type)) {
     return type();
   }
   throw new Error(ERROR_GET_NEW_SERIALIZABLE_SERIALIZABLE_NOT_RETURNED);

--- a/strategy/utils.ts
+++ b/strategy/utils.ts
@@ -1,9 +1,10 @@
 // Copyright 2018-2021 Gamebridge.ai authors. All rights reserved. MIT license.
 import { Serializable } from "../serializable.ts";
-import { isNewable } from "./_utils.ts";
+import { isCallable, isNewable } from "./_utils.ts";
+import { ERROR_GET_NEW_SERIALIZABLE_SERIALIZABLE_NOT_RETURNED } from "../error_messages.ts";
 
 export type NewSerializable<T> = T & (new () => Serializable);
-type FunctionSerializable = () => Serializable;
+export type FunctionSerializable = () => Serializable;
 /** for strategies can be a provided function
  * returning a `new` constructed type or
  * a raw type to be constructed  */
@@ -15,5 +16,10 @@ export type SerializableConstructor<T> =
 export function getNewSerializable<T>(
   type: SerializableConstructor<T>,
 ): Serializable {
-  return isNewable(type) ? new type() : type();
+  if (isNewable(type)) {
+    return new type();
+  } else if (isCallable(type)) {
+    return type();
+  }
+  throw new Error(ERROR_GET_NEW_SERIALIZABLE_SERIALIZABLE_NOT_RETURNED);
 }


### PR DESCRIPTION
**Description**

fixes a compile issue with `type()` not recognized as callable, added a type guard and error message 

fixes #121 

**Things to look at**

- [x] Test coverage
- [x] Code Style
- [x] Documentation (`README.md`, `doc/`, `examples/`, etc..)
