### PR TITLE
Test markdown code blocks

### DIFF
--- a/.github/test_markdown.ts
+++ b/.github/test_markdown.ts
@@ -6,7 +6,7 @@
 
 import { walk } from "https://deno.land/std@0.133.0/fs/mod.ts";
 
-enum CodeBlockTokens {
+enum CodeBlockToken {
   StartTs = "```ts",
   StartTypescript = "```typescript",
   End = "```",
@@ -26,15 +26,15 @@ for await (const { path } of walk(Deno.args[0] || ".", { exts: [".md"] })) {
     currentLine += 1;
     if (
       !readingCodeBlock &&
-      (line === CodeBlockTokens.StartTs ||
-        line === CodeBlockTokens.StartTypescript)
+      (line === CodeBlockToken.StartTs ||
+        line === CodeBlockToken.StartTypescript)
     ) {
       readingCodeBlock = true;
       startLine = currentLine;
       continue;
     }
 
-    if (readingCodeBlock && line === CodeBlockTokens.End) {
+    if (readingCodeBlock && line === CodeBlockToken.End) {
       readingCodeBlock = false;
       testSuite.set(
         path,

--- a/.github/test_markdown.ts
+++ b/.github/test_markdown.ts
@@ -1,8 +1,18 @@
 // Copyright 2018-2022 Gamebridge.ai authors. All rights reserved. MIT license.
 
-/** find and read all .md files in a given directory or the current directory
+/** Find and read all .md files in a given directory or the current directory
  * if no arguments are given, parse each .md file for typescript code blocks
- * and run the code in the codeblock */
+ * and run the code in the codeblock
+ *
+ * @argument directory - string path to the head of the directory stack
+ * @default "." - the currect location from where the script was run
+ *
+ * @example
+ * ```bash
+ * deno run --alow-read --allow-write --allow-run test_markdown.ts
+ * deno run --alow-read --allow-write --allow-run test_markdown.ts directory
+ * ```
+ */
 
 import { walk } from "https://deno.land/std@0.133.0/fs/mod.ts";
 

--- a/.github/test_markdown.ts
+++ b/.github/test_markdown.ts
@@ -1,0 +1,72 @@
+// Copyright 2018-2022 Gamebridge.ai authors. All rights reserved. MIT license.
+
+/** find and read all .md files in a given directory or the current directory
+ * if no arguments are given, parse each .md file for typescript code blocks
+ * and run the code in the codeblock */
+
+import { walk } from "https://deno.land/std@0.133.0/fs/mod.ts";
+
+enum CodeBlockTokens {
+  StartTs = "```ts",
+  StartTypescript = "```typescript",
+  End = "```",
+}
+
+/** build a testSuite from all .md files */
+const testSuite = new Map();
+
+for await (const { path } of walk(Deno.args[0] || ".", { exts: [".md"] })) {
+  testSuite.set(path, []);
+  const testLines = [];
+  let readingCodeBlock = false;
+  let currentLine = 0;
+  let startLine = 0;
+
+  for (const line of (await Deno.readTextFile(path)).split("\n")) {
+    currentLine += 1;
+    if (
+      !readingCodeBlock &&
+      (line === CodeBlockTokens.StartTs ||
+        line === CodeBlockTokens.StartTypescript)
+    ) {
+      readingCodeBlock = true;
+      startLine = currentLine;
+      continue;
+    }
+
+    if (readingCodeBlock && line === CodeBlockTokens.End) {
+      readingCodeBlock = false;
+      testSuite.set(
+        path,
+        [...testSuite.get(path), {
+          startLine,
+          endLine: currentLine,
+          test: testLines.join("\n"),
+        }],
+      );
+      testLines.length = 0;
+      continue;
+    }
+
+    if (readingCodeBlock) {
+      testLines.push(line);
+    }
+  }
+
+  if (testSuite.get(path).length === 0) {
+    testSuite.delete(path);
+  }
+}
+/** run the testSuite, and stop process with `code` with `sucess` fails */
+for (const [file, tests] of testSuite.entries()) {
+  for (const { startLine, endLine, test } of tests) {
+    const path = `${file}:${startLine}-${endLine}.ts`;
+    await Deno.writeTextFile(path, test);
+    const { success, code } = await Deno.run({ cmd: ["deno", "test", path] })
+      .status();
+    await Deno.remove(path);
+    if (!success) {
+      Deno.exit(code);
+    }
+  }
+}

--- a/.github/test_markdown.ts
+++ b/.github/test_markdown.ts
@@ -41,7 +41,7 @@ for await (const { path } of walk(Deno.args[0] || ".", { exts: [".md"] })) {
         [...testSuite.get(path), {
           startLine,
           endLine: currentLine,
-          test: testLines.join("\n"),
+          testCode: testLines.join("\n"),
         }],
       );
       testLines.length = 0;
@@ -59,9 +59,9 @@ for await (const { path } of walk(Deno.args[0] || ".", { exts: [".md"] })) {
 }
 /** run the testSuite, and stop process with `code` with `sucess` fails */
 for (const [file, tests] of testSuite.entries()) {
-  for (const { startLine, endLine, test } of tests) {
+  for (const { startLine, endLine, testCode } of tests) {
     const path = `${file}:${startLine}-${endLine}.ts`;
-    await Deno.writeTextFile(path, test);
+    await Deno.writeTextFile(path, testCode);
     const { success, code } = await Deno.run({ cmd: ["deno", "test", path] })
       .status();
     await Deno.remove(path);

--- a/.github/workflows/ts_serialize_release.yml
+++ b/.github/workflows/ts_serialize_release.yml
@@ -38,7 +38,7 @@ jobs:
         run: deno test --doc
 
       - name: Deno test markdown code blocks
-        run: deno --allow-read --allow-write --allow-run .github/test_markdown.ts
+        run: deno run --allow-read --allow-write --allow-run .github/test_markdown.ts
         if: matrix.os == 'ubuntu-latest'
 
       - name: Run package.json generation tests

--- a/.github/workflows/ts_serialize_release.yml
+++ b/.github/workflows/ts_serialize_release.yml
@@ -37,6 +37,10 @@ jobs:
       - name: Run deno tests
         run: deno test --doc
 
+      - name: Deno test markdown code blocks
+        run: deno --allow-read --allow-write --allow-run .github/test_markdown.ts
+        if: matrix.os == "ubuntu-latest"
+
       - name: Run package.json generation tests
         run: .github/workflows/scripts/npm_release_files/create_npm_package_file_test.sh
 

--- a/.github/workflows/ts_serialize_release.yml
+++ b/.github/workflows/ts_serialize_release.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Deno test markdown code blocks
         run: deno --allow-read --allow-write --allow-run .github/test_markdown.ts
-        if: matrix.os == "ubuntu-latest"
+        if: matrix.os == 'ubuntu-latest'
 
       - name: Run package.json generation tests
         run: .github/workflows/scripts/npm_release_files/create_npm_package_file_test.sh

--- a/.github/workflows/ts_serialize_tests.yml
+++ b/.github/workflows/ts_serialize_tests.yml
@@ -42,6 +42,10 @@ jobs:
       - name: Deno test
         run: deno test --doc
 
+      - name: Deno test markdown code blocks
+        run: deno --allow-read --allow-write --allow-run .github/test_markdown.ts
+        if: matrix.os == "ubuntu-latest"
+
       - name: Run package.json generation tests
         run: .github/workflows/scripts/npm_release_files/create_npm_package_file_test.sh
 

--- a/.github/workflows/ts_serialize_tests.yml
+++ b/.github/workflows/ts_serialize_tests.yml
@@ -43,7 +43,7 @@ jobs:
         run: deno test --doc
 
       - name: Deno test markdown code blocks
-        run: deno --allow-read --allow-write --allow-run .github/test_markdown.ts
+        run: deno run --allow-read --allow-write --allow-run .github/test_markdown.ts
         if: matrix.os == 'ubuntu-latest'
 
       - name: Run package.json generation tests

--- a/.github/workflows/ts_serialize_tests.yml
+++ b/.github/workflows/ts_serialize_tests.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Deno test markdown code blocks
         run: deno --allow-read --allow-write --allow-run .github/test_markdown.ts
-        if: matrix.os == "ubuntu-latest"
+        if: matrix.os == 'ubuntu-latest'
 
       - name: Run package.json generation tests
         run: .github/workflows/scripts/npm_release_files/create_npm_package_file_test.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 - _breaking_ fix #125 strategies are now passed the full array, this allows more
   flexibility for conversions
 - _breaking_ removes array as a strategy, use `composeStrategy` instead
+- adds #139 as a feature
 - fixes #141
 - fixes #139
 - move `docs/` to `README.md` and delete folder

--- a/README.md
+++ b/README.md
@@ -104,18 +104,16 @@ test({
       propertyTwo = "World!";
       @SerializeProperty({ serializedKey: (key) => `__${key}__` })
       propertyThree = "foo";
-      notSerialized = "not-serialized";
     }
     assertEquals(
       new Test().toJSON(),
       `{"propertyOne":"Hello","property_two":"World!","__propertyThree__":"foo"}`,
     );
     const testObj = new Test().fromJSON(
-      `{"propertyOne":"From","property_two":"JSON!","__propertyThree__":"bar","notSerialized":"changed"}`,
+      `{"propertyOne":"From","property_two":"JSON!","__propertyThree__":"bar"}`,
     );
     assertEquals(testObj.propertyOne, "From");
     assertEquals(testObj.propertyTwo, "JSON!");
-    assertEquals(testObj.notSerialized, "changed");
     assertEquals(
       testObj.toJSON(),
       `{"propertyOne":"From","property_two":"JSON!","__propertyThree__":"bar"}`,

--- a/README.md
+++ b/README.md
@@ -59,13 +59,7 @@ import { assert, assertEquals, test } from "./test_deps.ts";
 test({
   name: "Serializable adds 5 methods",
   fn() {
-    class TestClass extends Serializable {
-      @SerializeProperty()
-      public test: number = 99;
-
-      @SerializeProperty("test_one")
-      public test1: number = 100;
-    }
+    class TestClass extends Serializable {}
     const testObj = new TestClass();
     assert(testObj instanceof Serializable);
     assertEquals(typeof testObj.toJSON, "function");

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ serialized.
   takes the object as a parameter to override cloned property values
 
 ```ts
-import { Serializable, SerializeProperty } from "./mod.ts";
+import { Serializable } from "./mod.ts";
 import { assert, assertEquals, test } from "./test_deps.ts";
 
 test({


### PR DESCRIPTION
**Description**
fixes #139 

We can now run `deno run --allow-read --allow-write --allow-run .github/test_markdown.ts`

**Proposed changes in this PR**

- adds a script to: 
  - collect all `.md` files recursively
  - read each `.md` file for typescript code blocks
  - runs each code block as it's own file
- should we only run `test()` code blocks?

**Things to look at**

- [x] Test coverage
- [x] Code Style
- [x] Documentation (`README.md`, `CHANGELOG.md`, etc..)
