### PR TITLE
Add missing npm-build dependancy

### DIFF
--- a/_build_npm.ts
+++ b/_build_npm.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run --allow-env --allow-read --allow-write --allow-run=npm,cmd
+#!/usr/bin/env -S deno run --allow-env --allow-read --allow-write --allow-run=npm,cmd --allow-net=deno.land
 
 // Copyright 2018-2022 Gamebridge.ai authors. All rights reserved. MIT license.
 


### PR DESCRIPTION
**Description**

Add missing net permission to allow build to download dependancy files. Domain is restricted to `deno.land`

**Proposed changes in this PR**

- fixes issue where release CI fails due to missing network permission

**Things to look at**

- [ ] Test coverage
- [ ] Code Style
- [ ] Documentation (`README.md`, `CHANGELOG.md`, etc..)
