### PR TITLE
151 Added handling for null class objects

### DIFF
--- a/.github/workflows/ts_serialize_release.yml
+++ b/.github/workflows/ts_serialize_release.yml
@@ -35,7 +35,7 @@ jobs:
         run: deno cache test_deps.ts
 
       - name: Run deno tests
-        run: deno test --doc
+        run: deno test --doc -c tsconfig.json
 
   build:
     name: Release
@@ -62,7 +62,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v1
         with:
-          node-version: 16
+          node-version: 20
           registry-url: https://registry.npmjs.org/
 
       - name: Build and test NPM module

--- a/.github/workflows/ts_serialize_tests.yml
+++ b/.github/workflows/ts_serialize_tests.yml
@@ -40,12 +40,12 @@ jobs:
         run: deno cache test_deps.ts
 
       - name: Deno test
-        run: deno test --doc
+        run: deno test --doc -c tsconfig.json
 
       - name: Setup node
         uses: actions/setup-node@v1
         with:
-          node-version: 16
+          node-version: 20
           registry-url: https://registry.npmjs.org/
 
       - name: Build and test NPM module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.0.4] - 2025-02-26
+
+- fix #151 Allow the fromSerializationStrategy to handle null in place of an
+  serializable object.
+
 ## [v2.0.1 - v2.0.3] - 2022-04-15
 
 - NPM Deploy fixes

--- a/polymorphic_test.ts
+++ b/polymorphic_test.ts
@@ -28,6 +28,7 @@ test({
 
       fail("polymorphicClassFromJSON did not error with no context");
     } catch (e) {
+      assert(e instanceof Error);
       assertEquals(e.message, ERROR_FAILED_TO_RESOLVE_POLYMORPHIC_CLASS);
     }
   },
@@ -210,7 +211,7 @@ test({
     class TestClass extends AbstractClass {
       @SerializeProperty("class")
       @PolymorphicSwitch(() => new TestClass(), "TestClass")
-      public [symbol]: string;
+      public [symbol]: string = "";
 
       @SerializeProperty()
       public someProperty?: string;
@@ -344,7 +345,7 @@ test({
       @SerializeProperty()
       public someProperty = "original value";
 
-      public tsTransformKey(key: string): string {
+      public override tsTransformKey(key: string): string {
         return "+" + key;
       }
     }
@@ -361,7 +362,7 @@ test({
   name: "polymorphic switch supports inherited custom tsTransformKeys",
   fn() {
     abstract class AbstractClass extends Serializable {
-      public tsTransformKey(key: string): string {
+      public override tsTransformKey(key: string): string {
         return "!" + key;
       }
     }

--- a/serializable.ts
+++ b/serializable.ts
@@ -126,8 +126,7 @@ export function toPojo(
 
   if (!serializablePropertyMap) {
     throw new Error(
-      `${ERROR_MISSING_PROPERTIES_MAP}: ${context?.constructor
-        ?.prototype}`,
+      `${ERROR_MISSING_PROPERTIES_MAP}: ${context?.constructor?.prototype}`,
     );
   }
   const record: JSONObject = {};

--- a/serializable_test.ts
+++ b/serializable_test.ts
@@ -47,7 +47,7 @@ test({
   name: "runs TransformKey without implementation declaration",
   fn() {
     class TestTransformKey extends Serializable {
-      public tsTransformKey(key: string): string {
+      public override tsTransformKey(key: string): string {
         return `__${key}__`;
       }
 
@@ -67,7 +67,7 @@ test({
   name: "implements TransformKey to children",
   fn() {
     class TestTransformKey extends Serializable implements TransformKey {
-      public tsTransformKey(key: string): string {
+      public override tsTransformKey(key: string): string {
         return `__${key}__`;
       }
     }
@@ -103,7 +103,7 @@ test({
   name: "implements TransformKey to children and children can change",
   fn() {
     class TestTransformKey extends Serializable implements TransformKey {
-      public tsTransformKey(key: string): string {
+      public override tsTransformKey(key: string): string {
         return `__${key}__`;
       }
     }
@@ -114,7 +114,7 @@ test({
     }
 
     class TestTransformKey3 extends TestTransformKey2 implements TransformKey {
-      public tsTransformKey(key: string): string {
+      public override tsTransformKey(key: string): string {
         return `--${key}--`;
       }
       @SerializeProperty()
@@ -156,7 +156,7 @@ test({
   name: "implements TransformKey but respects override as string",
   fn() {
     class TestTransformKey extends Serializable implements TransformKey {
-      public tsTransformKey(key: string): string {
+      public override tsTransformKey(key: string): string {
         return `__${key}__`;
       }
     }
@@ -184,7 +184,7 @@ test({
   name: "implements TransformKey but respects override as property",
   fn() {
     class TestTransformKey extends Serializable implements TransformKey {
-      public tsTransformKey(key: string): string {
+      public override tsTransformKey(key: string): string {
         return `__${key}__`;
       }
     }
@@ -282,6 +282,7 @@ test({
       toPojo({} as Serializable);
       fail("to Pojo did not error with no context");
     } catch (e) {
+      assert(e instanceof Error);
       assertEquals(
         e.message,
         `${ERROR_MISSING_PROPERTIES_MAP}: [object Object]`,

--- a/serialize_property_options_map_test.ts
+++ b/serialize_property_options_map_test.ts
@@ -1,6 +1,12 @@
 // Copyright 2018-2022 Gamebridge.ai authors. All rights reserved. MIT license.
 
-import { assertEquals, assertStrictEquals, fail, test } from "./test_deps.ts";
+import {
+  assert,
+  assertEquals,
+  assertStrictEquals,
+  fail,
+  test,
+} from "./test_deps.ts";
 import {
   SerializePropertyOptionsMap,
 } from "./serialize_property_options_map.ts";
@@ -90,6 +96,7 @@ test({
       testObj.set(childSPOptions2);
       fail("Shouldn't be able to set duplicate property keys");
     } catch (e) {
+      assert(e instanceof Error);
       assertEquals(e.message, `${ERROR_DUPLICATE_PROPERTY_KEY}: a`);
     }
   },
@@ -107,6 +114,7 @@ test({
       testObj.set(childSPOptions2);
       fail("Shouldn't be able to set duplicate property keys");
     } catch (e) {
+      assert(e instanceof Error);
       assertEquals(e.message, `${ERROR_DUPLICATE_SERIALIZE_KEY}: a`);
     }
   },

--- a/serialize_property_test.ts
+++ b/serialize_property_test.ts
@@ -64,6 +64,7 @@ test({
       }
       fail("Allowed Symbol name without propertyName");
     } catch (e) {
+      assert(e instanceof Error);
       assertEquals(e.message, ERROR_SYMBOL_PROPERTY_NAME);
     }
   },
@@ -195,7 +196,7 @@ test({
   fn() {
     class Test extends Serializable {
       @SerializeProperty()
-      array!: unknown[];
+      array!: { subObj: string[] }[];
     }
     const testObj = new Test().fromJSON(
       `{"array":["worked",0,{"subObj":["cool"]}]}`,
@@ -270,6 +271,7 @@ test({
       }
       fail("Allowed duplicate propertyName");
     } catch (e) {
+      assert(e instanceof Error);
       assertEquals(
         e.message,
         `${ERROR_DUPLICATE_SERIALIZE_KEY}: serialize_me`,
@@ -324,7 +326,7 @@ test({
     }
     class Test2 extends Test1 {
       @SerializeProperty("serialize_me_2")
-      serializeMe = "nice2";
+      override serializeMe = "nice2";
     }
     const testObj = new Test2();
     assertEquals(testObj.serializeMe, "nice2");
@@ -341,7 +343,7 @@ test({
     }
     class Test2 extends Test1 {
       @SerializeProperty("serialize_me_2")
-      serializeMe = "nice2";
+      override serializeMe = "nice2";
     }
     const testObj = new Test2();
 

--- a/strategy/from_json/date_test.ts
+++ b/strategy/from_json/date_test.ts
@@ -33,6 +33,7 @@ test({
       new Test().fromJSON(`{"date":"I am not a date!"}`);
       fail("Non date string did not error");
     } catch (error) {
+      assert(error instanceof Error);
       assertEquals(error.message, ERROR_INVALID_DATE);
     }
   },
@@ -51,6 +52,7 @@ test({
       new Test().fromJSON(`{"date":"I am not a date!"}`);
       fail("Non date string did not error");
     } catch (error) {
+      assert(error instanceof Error);
       assertEquals(error.message, ERROR_INVALID_DATE);
     }
   },
@@ -116,6 +118,7 @@ test({
       new Test().fromJSON(`{"date":"Im going to shoot my foot"}`);
       fail("Non date string did not error");
     } catch (error) {
+      assert(error instanceof Error);
       assertEquals(error.message, ERROR_INVALID_DATE);
     }
   },

--- a/strategy/from_json/to_object_containing_test.ts
+++ b/strategy/from_json/to_object_containing_test.ts
@@ -111,6 +111,7 @@ test({
       );
       fail(`testObj ${testObj} did not fail`);
     } catch (error) {
+      assert(error instanceof Error);
       assertEquals(error.message, ERROR_TO_OBJECT_CONTAINING_INVALID_SUB_VALUE);
     }
   },
@@ -134,6 +135,7 @@ test({
       );
       fail(`testObj ${testObj} did not fail`);
     } catch (error) {
+      assert(error instanceof Error);
       assertEquals(error.message, ERROR_TO_OBJECT_CONTAINING_INVALID_VALUE);
     }
   },
@@ -163,6 +165,7 @@ test({
       );
       fail(`testObj ${testObj} did not fail`);
     } catch (error) {
+      assert(error instanceof Error);
       assertEquals(error.message, ERROR_TO_OBJECT_CONTAINING_INVALID_SUB_VALUE);
     }
   },

--- a/strategy/to_json/from_serializable.ts
+++ b/strategy/to_json/from_serializable.ts
@@ -10,6 +10,10 @@ export function fromSerializable(): ToJSONStrategy {
   ): JSONValue => {
     if (Array.isArray(value)) {
       return value.map((item) => item.tsSerialize());
+    } else if (value === null) {
+      // Objects can be null, return them without further serialization.
+      // Double cast required to return a JSONValue
+      return value as null as JSONValue;
     }
     return value.tsSerialize();
   };

--- a/strategy/to_json/from_serializable_test.ts
+++ b/strategy/to_json/from_serializable_test.ts
@@ -46,6 +46,33 @@ test({
 });
 
 test({
+  name:
+    "fromSerializable - arrays of nested objects with an object set to null",
+  fn() {
+    class Test1 extends Serializable {
+      @SerializeProperty("nested_property")
+      serializeMe = 999;
+    }
+    class Test2 extends Serializable {
+      @FromSerializable("outer_property")
+      nested: Test1[] | null = [new Test1()];
+    }
+
+    class Test3 extends Serializable {
+      @FromSerializable("outer_outer_property")
+      nested2: Test2[] | null = [new Test2()];
+    }
+    const testObj = new Test3();
+    testObj.nested2 = null;
+
+    assertEquals(
+      testObj.toJSON(),
+      `{"outer_outer_property":null}`,
+    );
+  },
+});
+
+test({
   name: "fromSerializable - single serializable objects",
   fn() {
     class Test1 extends Serializable {
@@ -66,6 +93,34 @@ test({
     assertEquals(
       testObj.toJSON(),
       `{"outer_outer_property":{"outer_property":{"nested_property":999}}}`,
+    );
+  },
+});
+
+test({
+  name:
+    "fromSerializable - single serializable objects with an object set to null",
+  fn() {
+    class Test1 extends Serializable {
+      @SerializeProperty("nested_property")
+      serializeMe = 999;
+    }
+    class Test2 extends Serializable {
+      @FromSerializable("outer_property")
+      nested: Test1 | null = new Test1();
+    }
+
+    class Test3 extends Serializable {
+      @FromSerializable("outer_outer_property")
+      nested2: Test2 | null = new Test2();
+    }
+
+    const testObj = new Test3();
+    testObj.nested2 = null;
+
+    assertEquals(
+      testObj.toJSON(),
+      `{"outer_outer_property":null}`,
     );
   },
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
-    "experimentalDecorators": true
+    "target": "ES5",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
   }
 }


### PR DESCRIPTION
**Description**

See issue 151 [here](https://github.com/GameBridgeAI/ts_serialize/issues/151)

**Proposed changes in this PR**

- Allow the fromSerializable strategy to return the primitive null value instead of having a null pointer exception.
  - We expect to send null in the request.
- Undefined is protected at the level above, which makes sense, as we don't want to send it over the wire. No changes to be made in that case.

**Things to look at**

- [x] Test coverage
- [x] Code Style
- [x] Documentation (`README.md`, `CHANGELOG.md`, etc..)
