### PR TITLE
fixes #151

### DIFF
--- a/.github/CONTRIBUTORS.md
+++ b/.github/CONTRIBUTORS.md
@@ -7,3 +7,4 @@
 - [@rgrosset](https://github.com/rgrosset) :shipit:
 - [@ms1111](https://github.com/ms1111) :eyes:
 - [@khan-saim](https://github.com/khan-saim)
+- [@WillForrestMindBridge](https://github.com/WillForrestMindBridge)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to
 - `catch(e)` where `e` is now `unknown` previously `any`
   - adds wrapper for error messages
 - add member accessor for all classes
+- fix #151 Allow the fromSerializationStrategy to handle null in place of an
+  serializable object.
 
 ## [v2.0.1 - v2.0.3] - 2022-04-15
 

--- a/strategy/to_json/from_serializable.ts
+++ b/strategy/to_json/from_serializable.ts
@@ -9,6 +9,8 @@ export function fromSerializable(): ToJSONStrategy {
     if (Array.isArray(value)) {
       return value.map((item) => item.tsSerialize());
     }
-    return value.tsSerialize();
+    // Objects can be null, return them without further serialization.
+    // Double cast required to return a JSONValue
+    return value ? value.tsSerialize() : value as null as JSONValue;
   };
 }

--- a/strategy/to_json/from_serializable_test.ts
+++ b/strategy/to_json/from_serializable_test.ts
@@ -44,6 +44,33 @@ test({
 });
 
 test({
+  name:
+    "fromSerializable - arrays of nested objects with an object set to null",
+  fn() {
+    class Test1 extends Serializable {
+      @SerializeProperty("nested_property")
+      public serializeMe = 999;
+    }
+    class Test2 extends Serializable {
+      @FromSerializable("outer_property")
+      public nested: Test1[] | null = [new Test1()];
+    }
+
+    class Test3 extends Serializable {
+      @FromSerializable("outer_outer_property")
+      public nested2: Test2[] | null = [new Test2()];
+    }
+    const testObj = new Test3();
+    testObj.nested2 = null;
+
+    assertEquals(
+      testObj.toJSON(),
+      `{"outer_outer_property":null}`,
+    );
+  },
+});
+
+test({
   name: "fromSerializable - single serializable objects",
   fn() {
     class Test1 extends Serializable {
@@ -64,6 +91,34 @@ test({
     assertEquals(
       testObj.toJSON(),
       `{"outer_outer_property":{"outer_property":{"nested_property":999}}}`,
+    );
+  },
+});
+
+test({
+  name:
+    "fromSerializable - single serializable objects with an object set to null",
+  fn() {
+    class Test1 extends Serializable {
+      @SerializeProperty("nested_property")
+      public serializeMe = 999;
+    }
+    class Test2 extends Serializable {
+      @FromSerializable("outer_property")
+      public nested: Test1 | null = new Test1();
+    }
+
+    class Test3 extends Serializable {
+      @FromSerializable("outer_outer_property")
+      public nested2: Test2 | null = new Test2();
+    }
+
+    const testObj = new Test3();
+    testObj.nested2 = null;
+
+    assertEquals(
+      testObj.toJSON(),
+      `{"outer_outer_property":null}`,
     );
   },
 });


### PR DESCRIPTION
**Description**

### Issues fixed ###
See issue #151 

**Proposed changes in this PR**


Issue 151
- Allow the fromSerializable strategy to return the primitive null value instead of having a null pointer exception.
  - We expect to send null in the request.
- Undefined is protected at the level above, which makes sense, as we don't want to send it over the wire. No changes to be made in that case.

**Things to look at**

- [x] Test coverage
- [x] Code Style
- [x] Documentation (`README.md`, `CHANGELOG.md`, etc..)
