### PR TITLE
Fix an issue where the release action fails

### DIFF
--- a/.github/workflows/ts_serialize_release.yml
+++ b/.github/workflows/ts_serialize_release.yml
@@ -32,7 +32,7 @@ jobs:
         if: matrix.os != 'windows-latest'
 
       - name: Run deno tests
-        run: deno task test --doc
+        run: deno task test
 
   build:
     name: Release


### PR DESCRIPTION
**Description**

Fixes an issue in the npm deploy script where the tests would fail as a result of --doc being set twice, once in the deno.json, and again in ts_serialize_release.yml

**Things to look at**

- [ ] Test coverage
- [ ] Code Style
- [ ] Documentation (`README.md`, `CHANGELOG.md`, etc..)
