### PR TITLE
Configure GitHub/npmjs trusted publishing

### DIFF
--- a/.github/workflows/ts_serialize_release.yml
+++ b/.github/workflows/ts_serialize_release.yml
@@ -6,6 +6,11 @@ on:
   push:
     tags: ["v*.*.*"]
 
+# OIDC setup for trusted publishing
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -76,9 +81,10 @@ jobs:
           draft: false
           prerelease: false
 
+      - name: Update npm to 11.5.1 or later for trusted publishing
+        run: npm install -g npm@latest
+
       - name: Deploy to NPM
         run: |
           cd dist
           npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
**Description**

npm added Trusted Publishing a few months back. It uses OpenID Connect to manage an automatically rotated token between GitHub and npmjs.

Given recent attacks on the npm ecosystem, I'd like to adopt this. I've set up the link on the npmjs side following the docs at https://docs.npmjs.com/trusted-publishers

**Proposed changes in this PR**

- When publishing to NPM, use the Trusted Publishing token instead of the static NPM token.

**Things to look at**

- [ ] Test coverage
- [ ] Code Style
- [ ] Documentation (`README.md`, `CHANGELOG.md`, etc..)
