### PR TITLE
Pin packages and add lockfile for reproducible builds

### DIFF
--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -25,13 +25,13 @@ This will add the deno types to the project.
 ## Running the tests
 
 ```bash
-$ deno test
+$ deno task test
 ```
 
 You can add a file to test only that one file.
 
 ```bash
-$ deno test mod_test.ts
+$ deno test --frozen mod_test.ts
 ```
 
 ### Coding style and tests

--- a/.github/workflows/ts_serialize_tests.yml
+++ b/.github/workflows/ts_serialize_tests.yml
@@ -30,7 +30,7 @@ jobs:
           deno-version: ${{ matrix.deno }}
 
       - name: Deno test
-        run: deno test
+        run: deno test --no-lock
 
   deno_v2_and_up:
     runs-on: ${{ matrix.os }}

--- a/_build_npm.ts
+++ b/_build_npm.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run --allow-env --allow-read --allow-write --allow-run=npm --allow-net=jsr.io
+#!/usr/bin/env -S deno run --allow-env --allow-read --allow-write --allow-run=npm --allow-net=jsr.io --frozen
 // Copyright 2018-2025 Gamebridge.ai authors. All rights reserved. MIT license.
 
 import { build, emptyDir } from "@deno/dnt";

--- a/deno.json
+++ b/deno.json
@@ -1,10 +1,10 @@
 {
   "imports": {
-    "@deno/dnt": "jsr:@deno/dnt@^0.42.1",
-    "@std/assert": "jsr:@std/assert@^1.0.13",
-    "@std/cli": "jsr:@std/cli@^1.0.17"
+    "@deno/dnt": "jsr:@deno/dnt@0.42.3",
+    "@std/assert": "jsr:@std/assert@1.0.14",
+    "@std/cli": "jsr:@std/cli@1.0.22"
   },
-  "lock": false,
+  "lock": true,
   "compilerOptions": {
     "experimentalDecorators": true
   },
@@ -39,11 +39,11 @@
     },
     "test": {
       "description": "Run tests",
-      "command": "deno test --doc"
+      "command": "deno test --doc --frozen"
     },
     "test:coverage": {
       "description": "Run tests with coverage",
-      "command": "deno test --coverage=coverage --doc"
+      "command": "deno test --coverage=coverage --doc --frozen"
     },
     "test:coverage:report": {
       "description": "Generate coverage report",

--- a/deno.lock
+++ b/deno.lock
@@ -1,0 +1,80 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@david/code-block-writer@^13.0.3": "13.0.3",
+    "jsr:@deno/dnt@0.42.3": "0.42.3",
+    "jsr:@std/assert@1.0.14": "1.0.14",
+    "jsr:@std/cli@1.0.22": "1.0.22",
+    "jsr:@std/fmt@1": "1.0.8",
+    "jsr:@std/fs@1": "1.0.19",
+    "jsr:@std/internal@^1.0.10": "1.0.10",
+    "jsr:@std/internal@^1.0.9": "1.0.10",
+    "jsr:@std/path@1": "1.1.2",
+    "jsr:@std/path@^1.1.1": "1.1.2",
+    "jsr:@ts-morph/bootstrap@0.27": "0.27.0",
+    "jsr:@ts-morph/common@0.27": "0.27.0"
+  },
+  "jsr": {
+    "@david/code-block-writer@13.0.3": {
+      "integrity": "f98c77d320f5957899a61bfb7a9bead7c6d83ad1515daee92dbacc861e13bb7f"
+    },
+    "@deno/dnt@0.42.3": {
+      "integrity": "62a917a0492f3c8af002dce90605bb0d41f7d29debc06aca40dba72ab65d8ae3",
+      "dependencies": [
+        "jsr:@david/code-block-writer",
+        "jsr:@std/fmt",
+        "jsr:@std/fs",
+        "jsr:@std/path@1",
+        "jsr:@ts-morph/bootstrap"
+      ]
+    },
+    "@std/assert@1.0.14": {
+      "integrity": "68d0d4a43b365abc927f45a9b85c639ea18a9fab96ad92281e493e4ed84abaa4",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.10"
+      ]
+    },
+    "@std/cli@1.0.22": {
+      "integrity": "50d1e4f87887cb8a8afa29b88505ab5081188f5cad3985460c3b471fa49ff21a"
+    },
+    "@std/fmt@1.0.8": {
+      "integrity": "71e1fc498787e4434d213647a6e43e794af4fd393ef8f52062246e06f7e372b7"
+    },
+    "@std/fs@1.0.19": {
+      "integrity": "051968c2b1eae4d2ea9f79a08a3845740ef6af10356aff43d3e2ef11ed09fb06",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.9",
+        "jsr:@std/path@^1.1.1"
+      ]
+    },
+    "@std/internal@1.0.10": {
+      "integrity": "e3be62ce42cab0e177c27698e5d9800122f67b766a0bea6ca4867886cbde8cf7"
+    },
+    "@std/path@1.1.2": {
+      "integrity": "c0b13b97dfe06546d5e16bf3966b1cadf92e1cc83e56ba5476ad8b498d9e3038",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.10"
+      ]
+    },
+    "@ts-morph/bootstrap@0.27.0": {
+      "integrity": "b8d7bc8f7942ce853dde4161b28f9aa96769cef3d8eebafb379a81800b9e2448",
+      "dependencies": [
+        "jsr:@ts-morph/common"
+      ]
+    },
+    "@ts-morph/common@0.27.0": {
+      "integrity": "c7b73592d78ce8479b356fd4f3d6ec3c460d77753a8680ff196effea7a939052",
+      "dependencies": [
+        "jsr:@std/fs",
+        "jsr:@std/path@1"
+      ]
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@deno/dnt@0.42.3",
+      "jsr:@std/assert@1.0.14",
+      "jsr:@std/cli@1.0.22"
+    ]
+  }
+}


### PR DESCRIPTION
**Description**

To ensure reproducibility and minimize susceptibility to supply chain attacks, use a lock file for dependencies. As suggested in https://github.com/GameBridgeAI/ts_serialize/pull/166#issuecomment-3339625062

Using lockfile for deno v2 only.

For v1, it'd be a different lockfile format, and given it's only a few, pinned, standard packages, the risk of using unpinned transitive dependencies is low, and I figure the v1 build will go away at some point.

**Things to look at**

- [ ] Test coverage
- [ ] Code Style
- [ ] Documentation (`README.md`, `CHANGELOG.md`, etc..)
